### PR TITLE
Loader-prop

### DIFF
--- a/src/UpupUploader.tsx
+++ b/src/UpupUploader.tsx
@@ -24,6 +24,7 @@ import {
     FC,
     ForwardedRef,
     LegacyRef,
+    ReactNode,
     RefAttributes,
     forwardRef,
     useEffect,
@@ -51,6 +52,7 @@ export interface UpupUploaderProps {
     googleConfigs?: GoogleConfigs | undefined
     maxFilesSize?: number | undefined
     oneDriveConfigs?: OneDriveConfigs | undefined
+    loader?: ReactNode
 }
 
 export type UploadFilesRef = {
@@ -79,6 +81,7 @@ export const UpupUploader: FC<UpupUploaderProps & RefAttributes<any>> =
             googleConfigs,
             maxFilesSize,
             oneDriveConfigs,
+            loader,
         } = props
         const { bucket, s3Configs } = cloudStorageConfigs
         const {
@@ -250,6 +253,7 @@ export const UpupUploader: FC<UpupUploaderProps & RefAttributes<any>> =
                     baseConfigs={baseConfigs}
                     setFiles={setFiles}
                     setView={setView}
+                    loader={loader}
                 />
             ),
             [UploadAdapter.LINK]: (

--- a/src/UpupUploader.tsx
+++ b/src/UpupUploader.tsx
@@ -24,7 +24,7 @@ import {
     FC,
     ForwardedRef,
     LegacyRef,
-    ReactNode,
+    ReactElement,
     RefAttributes,
     forwardRef,
     useEffect,
@@ -52,7 +52,7 @@ export interface UpupUploaderProps {
     googleConfigs?: GoogleConfigs | undefined
     maxFilesSize?: number | undefined
     oneDriveConfigs?: OneDriveConfigs | undefined
-    loader?: ReactNode
+    loader?: ReactElement | null
 }
 
 export type UploadFilesRef = {

--- a/src/components/OneDriveUploader.tsx
+++ b/src/components/OneDriveUploader.tsx
@@ -1,4 +1,4 @@
-import { Dispatch, FC, SetStateAction } from 'react'
+import { Dispatch, FC, ReactNode, SetStateAction } from 'react'
 import { BaseConfigs, OneDriveConfigs } from 'types'
 import useOneDrive from '../hooks/useOneDrive'
 import FileBrowser from './UpupUploader/FileBrowser/BrowserOD'
@@ -8,6 +8,7 @@ interface Props {
     oneDriveConfigs: OneDriveConfigs
     setFiles: Dispatch<SetStateAction<File[]>>
     setView: Dispatch<SetStateAction<string>>
+    loader?: ReactNode
 }
 
 /**
@@ -20,12 +21,13 @@ const OneDriveUploader: FC<Props> = ({
     oneDriveConfigs,
     setFiles,
     setView,
+    loader,
 }: Props) => {
     const { user, oneDriveFiles, downloadFile, signOut } = useOneDrive(
         oneDriveConfigs.onedrive_client_id,
     )
 
-    if (!oneDriveFiles) return <div>One Sec..</div>
+    if (!oneDriveFiles) return loader
 
     return (
         <FileBrowser

--- a/src/components/OneDriveUploader.tsx
+++ b/src/components/OneDriveUploader.tsx
@@ -1,4 +1,4 @@
-import { Dispatch, FC, ReactNode, SetStateAction } from 'react'
+import { Dispatch, FC, ReactElement, SetStateAction } from 'react'
 import { BaseConfigs, OneDriveConfigs } from 'types'
 import useOneDrive from '../hooks/useOneDrive'
 import FileBrowser from './UpupUploader/FileBrowser/BrowserOD'
@@ -8,7 +8,7 @@ interface Props {
     oneDriveConfigs: OneDriveConfigs
     setFiles: Dispatch<SetStateAction<File[]>>
     setView: Dispatch<SetStateAction<string>>
-    loader?: ReactNode
+    loader?: ReactElement | null
 }
 
 /**
@@ -27,7 +27,7 @@ const OneDriveUploader: FC<Props> = ({
         oneDriveConfigs.onedrive_client_id,
     )
 
-    if (!oneDriveFiles) return loader
+    if (!oneDriveFiles) return loader || <div>Loading...</div>
 
     return (
         <FileBrowser

--- a/stories/Uploader.stories.tsx
+++ b/stories/Uploader.stories.tsx
@@ -1,3 +1,4 @@
+import { CircularProgress } from '@mui/material'
 import { Meta } from '@storybook/react'
 import { useRef } from 'react'
 import {
@@ -48,6 +49,9 @@ const Uploader = args => {
             console.error('Error uploading files:', error)
         }
     }
+
+    const loader = <CircularProgress size={100} />
+
     return (
         <>
             <UpupUploader
@@ -57,6 +61,7 @@ const Uploader = args => {
                 cloudStorageConfigs={cloudStorageConfigs}
                 googleConfigs={googleConfigs}
                 oneDriveConfigs={oneDriveConfigs}
+                loader={loader}
                 ref={upupRef}
             />
             <button onClick={handleUpload}>Upload</button>


### PR DESCRIPTION
FIX https://github.com/uNotesOfficial/unotes-next/issues/1071

Add the ability to accept a loader from the parent component, so w'll be able to pass either uNotes spinner book or the circular progress like this:
[screen-capture (3).webm](https://github.com/uNotesOfficial/upup/assets/36534106/482dd609-6473-41cc-9c16-0f8a41e0fb4c)
