### PR TITLE
fix: revoke blob URLs to prevent memory leak

### DIFF
--- a/packages/upup/src/frontend/hooks/useRootProvider.ts
+++ b/packages/upup/src/frontend/hooks/useRootProvider.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import {
     TbCameraRotate,
     TbCapture,
@@ -77,6 +77,19 @@ export default function useRootProvider({
         {} as FilesProgressMap,
     )
     const [uploadError, setUploadError] = useState('')
+
+    // Keep a ref to selectedFilesMap for unmount cleanup
+    const selectedFilesMapRef = useRef(selectedFilesMap)
+    useEffect(() => {
+        selectedFilesMapRef.current = selectedFilesMap
+    }, [selectedFilesMap])
+
+    // Revoke all blob URLs on unmount to prevent memory leaks in SPAs
+    useEffect(() => {
+        return () => {
+            selectedFilesMapRef.current.forEach(file => revokeFileUrl(file))
+        }
+    }, [])
 
     const limit = useMemo(
         () => (mini ? 1 : Math.max(propLimit, 1)),

--- a/packages/upup/src/frontend/hooks/useRootProvider.ts
+++ b/packages/upup/src/frontend/hooks/useRootProvider.ts
@@ -17,6 +17,7 @@ import {
     checkFileSize,
     compressFile,
     fileAppendParams,
+    revokeFileUrl,
     sizeToBytes,
 } from '../lib/file'
 import { ProviderSDK } from '../lib/storage/provider'
@@ -124,6 +125,9 @@ export default function useRootProvider({
         return await proceedUpload(filesToUpload)
     }
     function dynamicallyReplaceFiles(files: File[] | FileWithParams[]) {
+        // Revoke old blob URLs to prevent memory leak
+        selectedFilesMap.forEach(file => revokeFileUrl(file))
+
         const filesMap = new Map<string, FileWithParams>()
         if (isFileWithParamsArray(files)) {
             for (const f of files) {
@@ -162,6 +166,7 @@ export default function useRootProvider({
             if (!checkFileType(accept, file)) {
                 onError(`${file.name} has an unsupported type!`)
                 onFileTypeMismatch(file, accept)
+                revokeFileUrl(fileWithParams)
                 continue
             }
 
@@ -173,11 +178,13 @@ export default function useRootProvider({
                 onError(
                     `${file.name} is larger than ${maxFileSize.size} ${maxFileSize.unit}!`,
                 )
+                revokeFileUrl(fileWithParams)
                 continue
             }
 
             if (newFilesMap.has(fileWithParams.id)) {
                 onWarn(`${file.name} has previously been selected`)
+                revokeFileUrl(fileWithParams)
                 continue
             }
 
@@ -186,6 +193,7 @@ export default function useRootProvider({
                 onWarn(
                     `A file with this url: ${fileUrl} has previously been selected`,
                 )
+                revokeFileUrl(fileWithParams)
                 continue
             }
 
@@ -205,12 +213,16 @@ export default function useRootProvider({
 
     const handleFileRemove = useCallback(
         (fileId: string) => {
+            const file = selectedFilesMap.get(fileId)
+            if (!file) return
+
+            // Revoke blob URL to prevent memory leak
+            revokeFileUrl(file)
+
             const selectedFilesMapCopy = new Map(selectedFilesMap)
             selectedFilesMapCopy.delete(fileId)
 
             setSelectedFilesMap(selectedFilesMapCopy)
-
-            const file = selectedFilesMap.get(fileId)!
             onFileRemove(file)
         },
         [onFileRemove, selectedFilesMap],
@@ -341,10 +353,13 @@ export default function useRootProvider({
         ],
     )
     const handleCancel = useCallback(() => {
+        // Revoke all blob URLs to prevent memory leak
+        selectedFilesMap.forEach(file => revokeFileUrl(file))
+
         setUploadStatus(UploadStatus.PENDING)
         setSelectedFilesMap(new Map())
         setFilesProgressMap({})
-    }, [])
+    }, [selectedFilesMap])
 
     const handleDone = useCallback(() => {
         onDoneClicked()

--- a/packages/upup/src/frontend/lib/file.ts
+++ b/packages/upup/src/frontend/lib/file.ts
@@ -51,6 +51,16 @@ export const fileAppendParams = (file: File) => {
     return file as FileWithParams
 }
 
+/**
+ * Revokes a blob URL to free memory. Safe to call on any file URL.
+ * @param file - FileWithParams object containing the URL to revoke
+ */
+export const revokeFileUrl = (file: FileWithParams) => {
+    if (file.url?.startsWith('blob:')) {
+        URL.revokeObjectURL(file.url)
+    }
+}
+
 export async function compressFile(oldFile: FileWithParams) {
     const buffer = await oldFile.arrayBuffer()
 
@@ -63,6 +73,9 @@ export async function compressFile(oldFile: FileWithParams) {
     newFileWithParams.thumbnail = oldFile.thumbnail
     newFileWithParams.fileHash = oldFile.fileHash
     newFileWithParams.key = oldFile.key
+
+    // Revoke old blob URL to prevent memory leak
+    revokeFileUrl(oldFile)
 
     return newFileWithParams
 }


### PR DESCRIPTION
Memory leak - blob URLs never revoked 

while am uploading files and removing them and uploading others it keeps using my memory more and more without cleaning -> memory grows with each file selection cycle

This is a fix to this problem 

#296 
