### PR TITLE
Clear the remaining homepage Lighthouse accessibility audits

### DIFF
--- a/apps/landing/src/components/FeatureShowcase/index.tsx
+++ b/apps/landing/src/components/FeatureShowcase/index.tsx
@@ -150,7 +150,9 @@ function FeatureRow({ row, index }: { row: HeroRow; index: number }) {
                 {row.live && (
                     <a
                         href="#demo"
-                        aria-label={`See ${row.title} live`}
+                        // WCAG 2.5.3: the accessible name must contain the
+                        // visible text ("See it live"), so it leads.
+                        aria-label={`See it live — ${row.title}`}
                         className="group mt-5 inline-flex items-center gap-1.5 text-sm font-semibold text-blue-600 transition-opacity hover:opacity-80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-transparent dark:text-blue-400"
                     >
                         See it live

--- a/apps/landing/src/components/HomepageFeatures/index.tsx
+++ b/apps/landing/src/components/HomepageFeatures/index.tsx
@@ -331,7 +331,7 @@ const fileTypes = [
         types: 'ZIP, RAR, 7Z, TAR',
     },
     {
-        icon: <SiJavascript className="w-8 h-8" />,
+        icon: <SiJavascript className="w-8 h-8" aria-hidden />,
         label: 'Code',
         types: 'JS, TS, JSON, XML',
     },
@@ -608,7 +608,10 @@ const SupportedWall: React.FC<{ providers: Integration[] }> = ({
                     >
                         <div className="flex h-full flex-col items-center gap-2.5 rounded-xl border border-black/5 bg-[var(--bg-base)] px-3 py-4 text-center dark:border-white/10">
                             <span className="flex h-9 w-9 items-center justify-center rounded-lg border border-black/5 bg-black/[0.03] text-gray-600 dark:border-white/10 dark:bg-white/[0.05] dark:text-gray-400">
-                                <provider.icon className="h-5 w-5" />
+                                <provider.icon
+                                    className="h-5 w-5"
+                                    aria-hidden
+                                />
                             </span>
                             <span className="text-xs font-medium leading-tight text-gray-900 dark:text-white">
                                 {provider.name}
@@ -644,7 +647,7 @@ const PlannedStrip: React.FC<PlannedStripProps> = ({
                     onClick={() => onProviderClick(provider)}
                     className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full border border-black/5 dark:border-white/10 text-xs font-medium text-gray-600 dark:text-gray-400 hover:border-black/10 dark:hover:border-white/20 hover:text-gray-900 dark:hover:text-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
                 >
-                    <provider.icon className="w-3.5 h-3.5" />
+                    <provider.icon className="w-3.5 h-3.5" aria-hidden />
                     {provider.name}
                 </button>
             ))}

--- a/apps/landing/src/components/HomepageHero/index.tsx
+++ b/apps/landing/src/components/HomepageHero/index.tsx
@@ -344,6 +344,7 @@ export default function HeroSection({
                                             {/* Copy Button */}
                                             <motion.button
                                                 onClick={handleCopy}
+                                                aria-label="Copy install command"
                                                 className="p-2 rounded-lg bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors"
                                                 whileHover={{ scale: 1.05 }}
                                                 whileTap={{ scale: 0.95 }}

--- a/apps/landing/src/components/StackBlitzDemoSection/index.tsx
+++ b/apps/landing/src/components/StackBlitzDemoSection/index.tsx
@@ -255,7 +255,10 @@ export default function StackBlitzDemoSection() {
                                     onClick={openInStackBlitz}
                                     className="inline-flex items-center gap-2 rounded-lg bg-primary/10 px-3 py-1.5 text-sm font-medium text-primary transition-colors hover:bg-primary/20 dark:bg-primary-dark/10 dark:text-primary-dark dark:hover:bg-primary-dark/20"
                                 >
-                                    <SiStackblitz className="w-4 h-4" />
+                                    <SiStackblitz
+                                        className="w-4 h-4"
+                                        aria-hidden
+                                    />
                                     Open in StackBlitz
                                 </button>
                                 <button
@@ -272,7 +275,10 @@ export default function StackBlitzDemoSection() {
                         <div className="relative">
                             {embedFailed ? (
                                 <div className="flex h-[75vh] flex-col items-center justify-center gap-4 bg-gray-950 px-6 text-center">
-                                    <SiStackblitz className="h-12 w-12 text-primary-dark" />
+                                    <SiStackblitz
+                                        className="h-12 w-12 text-primary-dark"
+                                        aria-hidden
+                                    />
                                     <p className="max-w-md text-sm text-gray-300">
                                         The embedded editor could not load here.
                                         Open the same example in StackBlitz to
@@ -282,7 +288,10 @@ export default function StackBlitzDemoSection() {
                                         onClick={openInStackBlitz}
                                         className="inline-flex items-center gap-2 rounded-xl bg-primary px-6 py-3 font-semibold text-white transition-opacity hover:opacity-90"
                                     >
-                                        <SiStackblitz className="w-5 h-5" />
+                                        <SiStackblitz
+                                            className="w-5 h-5"
+                                            aria-hidden
+                                        />
                                         Open in StackBlitz
                                         <ExternalLink className="w-4 h-4" />
                                     </button>
@@ -363,7 +372,10 @@ export default function StackBlitzDemoSection() {
                                     onClick={openInStackBlitz}
                                     className="inline-flex items-center gap-2 px-3 py-1.5 bg-white/10 hover:bg-white/20 text-white rounded-lg text-sm font-medium transition-colors"
                                 >
-                                    <SiStackblitz className="w-4 h-4" />
+                                    <SiStackblitz
+                                        className="w-4 h-4"
+                                        aria-hidden
+                                    />
                                     Open in StackBlitz
                                 </button>
                                 <button

--- a/apps/landing/src/components/UploaderScene/BeatChips.tsx
+++ b/apps/landing/src/components/UploaderScene/BeatChips.tsx
@@ -44,7 +44,6 @@ export default function BeatChips({
                     <button
                         key={beat.id}
                         type="button"
-                        aria-label={`Play the ${beat.label} part of the demo`}
                         aria-disabled={frozen || undefined}
                         onClick={() => onSelect(beat.seekTo)}
                         className={`inline-flex items-center gap-1.5 rounded-full border px-3 py-1.5 text-xs font-medium transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500 ${
@@ -59,6 +58,12 @@ export default function BeatChips({
                                 Popular
                             </span>
                         )}
+                        {/* Name-from-contents so the visible label (incl. the
+                            Popular badge) leads the accessible name — an
+                            aria-label that omits the badge fails WCAG 2.5.3. */}
+                        <span className="sr-only">
+                            — play this part of the demo
+                        </span>
                     </button>
                 )
             })}

--- a/apps/landing/src/components/UploaderScene/ResumeScene.tsx
+++ b/apps/landing/src/components/UploaderScene/ResumeScene.tsx
@@ -96,7 +96,7 @@ export default function ResumeScene({
                 <AnimatePresence>
                     {state.resumed && (
                         <motion.span
-                            className="absolute right-4 top-4 z-40 inline-flex items-center gap-1 rounded-full bg-emerald-500 px-2 py-1 text-[11px] font-semibold text-white shadow-lg"
+                            className="absolute right-4 top-4 z-40 inline-flex items-center gap-1 rounded-full bg-emerald-700 px-2 py-1 text-[11px] font-semibold text-white shadow-lg"
                             initial={
                                 frozen ? false : { scale: 0.6, opacity: 0 }
                             }

--- a/packages/interactive-example/src/styles.css
+++ b/packages/interactive-example/src/styles.css
@@ -23,8 +23,11 @@
     --ie-switch-bg-on: #3b82f6;
     --ie-switch-thumb: #ffffff;
 
-    --ie-accent: #3b82f6;
-    --ie-accent-soft: rgba(59, 130, 246, 0.12);
+    /* Accent doubles as small text on light surfaces and as a solid bg under
+       white text (--ie-accent-fg) — blue-600 keeps both ≥4.5:1 (WCAG AA);
+       blue-500 fails both at 3.7:1. */
+    --ie-accent: #2563eb;
+    --ie-accent-soft: rgba(37, 99, 235, 0.12);
     --ie-accent-strong: #1d4ed8;
     --ie-accent-fg: #ffffff;
 
@@ -100,6 +103,9 @@ html.dark .upup-ie-focus:not([data-theme="light"]),
     --ie-accent: #60a5fa;
     --ie-accent-soft: rgba(96, 165, 250, 0.16);
     --ie-accent-strong: #93c5fd;
+    /* Dark surfaces flip the pairing: light-blue accent bg needs DARK text —
+       the light theme's white --ie-accent-fg is 2.5:1 on #60a5fa. */
+    --ie-accent-fg: #0f172a;
     color-scheme: dark;
 }
 
@@ -122,6 +128,8 @@ html.dark .upup-ie-focus:not([data-theme="light"]),
         --ie-accent: #60a5fa;
         --ie-accent-soft: rgba(96, 165, 250, 0.16);
         --ie-accent-strong: #93c5fd;
+        /* Same dark-text-on-light-accent flip as the html.dark block above. */
+        --ie-accent-fg: #0f172a;
         color-scheme: dark;
     }
 }
@@ -1408,8 +1416,11 @@ html.dark .upup-ie-preview-placeholder,
     --ie-popover-bg: #ffffff;
     --ie-input-bg: rgba(255, 255, 255, 0.6);
     --ie-input-border: rgba(209, 213, 219, 0.7);
-    --ie-accent: #3b82f6;
-    --ie-accent-soft: rgba(59, 130, 246, 0.12);
+    /* Accent doubles as small text on light surfaces and as a solid bg under
+       white text (--ie-accent-fg) — blue-600 keeps both ≥4.5:1 (WCAG AA);
+       blue-500 fails both at 3.7:1. */
+    --ie-accent: #2563eb;
+    --ie-accent-soft: rgba(37, 99, 235, 0.12);
     --ie-accent-strong: #1d4ed8;
     --ie-accent-fg: #ffffff;
     --ie-radius-card: 16px;
@@ -1445,6 +1456,9 @@ html.dark .upup-ie-ai-panel,
     --ie-accent: #60a5fa;
     --ie-accent-soft: rgba(96, 165, 250, 0.16);
     --ie-accent-strong: #93c5fd;
+    /* Dark surfaces flip the pairing: light-blue accent bg needs DARK text —
+       the light theme's white --ie-accent-fg is 2.5:1 on #60a5fa. */
+    --ie-accent-fg: #0f172a;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -1460,6 +1474,8 @@ html.dark .upup-ie-ai-panel,
         --ie-accent: #60a5fa;
         --ie-accent-soft: rgba(96, 165, 250, 0.16);
         --ie-accent-strong: #93c5fd;
+        /* Same dark-text-on-light-accent flip as the html.dark block above. */
+        --ie-accent-fg: #0f172a;
     }
 }
 


### PR DESCRIPTION
## Summary
Fixes the four remaining homepage a11y audit failures the Lighthouse baseline surfaced (follow-up to #335):
- **button-name** — hero copy-command icon button gets `aria-label="Copy install command"`.
- **svg-img-alt** — react-icons simple-icons SVGs ship `role="img"` with no accessible name; every decorative `Si*` usage (provider grids, roadmap chips, StackBlitz buttons, accepted-types icon) is now `aria-hidden`.
- **label-content-name-mismatch** (WCAG 2.5.3) — "See it live" feature links lead with the visible text; hero beat chips switch from `aria-label` to name-from-contents + an `sr-only` suffix so the Popular badge is always contained in the name.
- **color-contrast** — interactive-example active tab was white-on-#60a5fa (2.5:1, dark) / white-on-#3b82f6 (3.7:1, light). Light `--ie-accent` → blue-600 `#2563eb`; the four dark theme blocks override `--ie-accent-fg` → `#0f172a` (6.6:1). ResumeScene "live" badge emerald-500 → emerald-700 (5.5:1).

Remaining homepage failures are external or product UI by prior ruling: third-party cookies (StackBlitz embed + ads tag) and the uploader-panel credit-link target-size (cross-framework DOM contract — 3.2 batch).

## Test Plan
- [x] Local production build re-audited (Lighthouse 12.x mobile): home + /react/ accessibility **89 → 97**; only third-party-cookies, inspector-issues, target-size remain
- [x] Docs pages unaffected (their sole remaining failure is the product-UI target-size)
- [x] landing + interactive-example: typecheck, lint, unit suites (63 + 87), prettier on touched files — all green
- [x] Visual check of the recolored active tab (dark text on light-blue) — consistent with the flat-hairline system