### PR TITLE
fix(landing): 301 the docs.useupup.com alias host into useupup.com/docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -355,7 +355,12 @@ the suites actually drive):
   final `@upupjs` — the `@useupup` 3.0.0 packages are deprecated/superseded. The
   brand, DOM contract strings, and the GitHub repo stay bare `upup`; the docs/
   landing domain stays `useupup.com` (a deliberate split — npm scope `@upupjs`,
-  web `useupup.com` — revisit if `upupjs.com` is ever adopted). `@upup` is a
+  web `useupup.com` — revisit if `upupjs.com` is ever adopted). `docs.useupup.com`
+  is a redirect-only alias for the commonly guessed docs-URL shape: host-based
+  301s in `apps/landing/next.config.mjs` send every path into
+  `useupup.com/docs/*` (plus a Dokploy domain entry on the prod compose routing
+  the host to the landing container) — it must never serve content directly, so
+  there is never a second indexable docs origin. `@upup` is a
   retired token — `pnpm run vocab:check` fails on any survivor.
 - `Upup*` — public entry points / brand: `UpupUploader`, `UpupThemeProvider`.
 - `Uploader*` — shared internal UI/controller layer: `UploaderPanel`,

--- a/apps/landing/next.config.mjs
+++ b/apps/landing/next.config.mjs
@@ -8,6 +8,16 @@ const repoRoot = join(__dirname, '../..')
 /** @type {import('next').NextConfig} */
 const isDev = process.env.NODE_ENV !== 'production'
 
+// Build-time mirror of src/lib/site-url.ts (next.config cannot import from
+// src). The docs subdomain (`docs.<host>`) is a courtesy alias for agents and
+// humans guessing the common docs-URL shape — it 301s into the canonical
+// `/docs` path on the main host rather than serving content, so there is
+// never a second indexable docs origin.
+const SITE_BASE = (
+    process.env.NEXT_PUBLIC_BASE_URL || 'https://useupup.com'
+).replace(/\/+$/, '')
+const DOCS_ALIAS_HOST = `docs.${new URL(SITE_BASE).host}`
+
 const nextConfig = {
     reactStrictMode: true,
     pageExtensions: ['js', 'jsx', 'ts', 'tsx'],
@@ -106,6 +116,25 @@ const nextConfig = {
             {
                 source: '/documentation/:path*',
                 destination: '/docs/:path*',
+                permanent: true,
+            },
+            // docs.<host> alias — placed AFTER the /documentation rules on
+            // purpose: a legacy path on the alias host takes the relative
+            // /documentation/* -> /docs/* hop first (staying on the alias
+            // host), then the /docs/* rule below moves it to the main host —
+            // two hops, correct final URL. The /docs/* source must precede
+            // the catch-all so an already-prefixed path isn't doubled to
+            // /docs/docs/*.
+            {
+                source: '/docs/:path*',
+                has: [{ type: 'host', value: DOCS_ALIAS_HOST }],
+                destination: `${SITE_BASE}/docs/:path*`,
+                permanent: true,
+            },
+            {
+                source: '/:path*',
+                has: [{ type: 'host', value: DOCS_ALIAS_HOST }],
+                destination: `${SITE_BASE}/docs/:path*`,
                 permanent: true,
             },
         ]


### PR DESCRIPTION
## Summary
- AI agents and humans commonly guess `docs.<domain>` as the docs URL; `docs.useupup.com` resolved via the Cloudflare wildcard but 404ed at Traefik (no router for the host).
- Adds host-based permanent redirects in `apps/landing/next.config.mjs`: every path on the `docs.<base-host>` alias 301s into the canonical `useupup.com/docs/*` surface. Already-prefixed `/docs/*` paths are not doubled; legacy `/documentation/*` takes its existing relative hop first, then moves host. The alias never serves content, so no second indexable docs origin exists.
- Records the ruling in CLAUDE.md's naming section.
- Infra half (done, applies on next deploy): Dokploy domain entry `docs.useupup.com` -> `landing:3000` on the UpupProdSite compose.

## Test Plan
- [x] Dev-server Host-header curls: bare host -> `/docs`, deep path prefixed once, `/docs/*` not doubled, `llms.txt` -> `/docs/llms.txt`, legacy `/documentation/*` chains correctly; normal host unaffected (`/` and `/docs/` still 200).
- [x] `pnpm --filter @upupjs/landing run lint` green; pre-commit (core/react/server suites) + pre-push (typecheck/lint/knip) green.
- [ ] CI checks green.
- [ ] Post-deploy live check: `https://docs.useupup.com/quickstarts/react/` -> 301/308 chain -> 200 at `https://useupup.com/docs/quickstarts/react/`.