### PR TITLE
release: nightly storybook-build fix + PR-gated static builds + loud nightly failures

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -28,6 +28,7 @@ jobs:
             minio: ${{ steps.resolve.outputs.minio }}
             smoke: ${{ steps.resolve.outputs.smoke }}
             docsE2e: ${{ steps.resolve.outputs.docsE2e }}
+            storybook: ${{ steps.resolve.outputs.storybook }}
         steps:
             - name: Checkout the repository (full history for merge-base diff)
               uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -218,6 +219,37 @@ jobs:
                       apps/e2e-test/test-results/
                   retention-days: 14
 
+    # The six static `storybook build` productions. Nightly-only until now, and
+    # nightly-only is why they rotted unnoticed for weeks: a production build
+    # CODE-SPLITS, dev-mode storybook does not, so the vite `worker.format`
+    # failure that @upupjs/core's module pipeline worker triggers was invisible
+    # to every PR gate (the cross-framework e2e suite boots the storybooks in
+    # DEV mode). Browser-less, MinIO-less, secret-less — cheap enough to gate.
+    # Same turbo task nightly.yml runs; both call `pnpm run build:storybook`.
+    Storybook-Builds:
+        name: Static storybook builds (all six frameworks)
+        runs-on: ubuntu-latest
+        needs: [Resolve-Affected]
+        if: needs.Resolve-Affected.outputs.storybook == 'true'
+        steps:
+            - name: Checkout the repository
+              uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+            - name: Setup pnpm
+              uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v4.4.0
+
+            - name: Setup Node.js
+              uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+              with:
+                  node-version-file: '.nvmrc'
+                  cache: pnpm
+
+            - name: Install dependencies
+              run: pnpm install --frozen-lockfile
+
+            - name: Build every storybook statically # turbo builds the workspace deps first
+              run: pnpm run build:storybook
+
     # Rollup aggregator for this workflow (F-780): main.yml's Status-Check spans
     # only main.yml jobs, so E2E + Smoke-Packages were aggregated by nothing.
     # Branch protection must require BOTH this job AND main.yml's Status Check.
@@ -227,7 +259,8 @@ jobs:
     E2E-Status:
         name: E2E Status Check
         runs-on: ubuntu-latest
-        needs: [Resolve-Affected, E2E, Smoke-Packages, Docs-E2E]
+        needs:
+            [Resolve-Affected, E2E, Smoke-Packages, Docs-E2E, Storybook-Builds]
         if: always()
         steps:
             - name: Check status (respecting resolver-sanctioned skips)
@@ -239,6 +272,8 @@ jobs:
                   SMOKE_WANTED: ${{ needs.Resolve-Affected.outputs.smoke }}
                   DOCS_RESULT: ${{ needs.Docs-E2E.result }}
                   DOCS_WANTED: ${{ needs.Resolve-Affected.outputs.docsE2e }}
+                  STORYBOOK_RESULT: ${{ needs.Storybook-Builds.result }}
+                  STORYBOOK_WANTED: ${{ needs.Resolve-Affected.outputs.storybook }}
               run: |
                   fail=0
                   if [ "$RESOLVE_RESULT" != "success" ]; then
@@ -262,6 +297,7 @@ jobs:
                   check "E2E" "$E2E_RESULT" "$E2E_WANTED"
                   check "Smoke-Packages" "$SMOKE_RESULT" "$SMOKE_WANTED"
                   check "Docs-E2E" "$DOCS_RESULT" "$DOCS_WANTED"
+                  check "Storybook-Builds" "$STORYBOOK_RESULT" "$STORYBOOK_WANTED"
                   if [ "$fail" -ne 0 ]; then
                     echo "E2E status check failed"
                     exit 1

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -4,10 +4,14 @@ permissions:
     contents: read
 
 # Deep suites too slow or too external for every PR: the full e2e gate plus
-# the a11y/overflow sweep, static storybook builds, the tarball consumer, and
-# the mastra LLM evals (paid key; loudly skipped when the secret is absent —
-# never a silent green). PR routing lives in e2e.yml via
+# the a11y/overflow sweep, the tarball consumer, and the mastra LLM evals (paid
+# key; loudly skipped when the secret is absent — never a silent green). The
+# static storybook builds also run in e2e.yml now (routed) — nightly keeps its
+# unrouted copy as full-breadth coverage. PR routing lives in e2e.yml via
 # scripts/ci/resolve-affected-tests.mjs; nightly always runs everything.
+#
+# A red nightly files/updates a `nightly-failure` tracking issue (Nightly-Status
+# below) — a scheduled run nobody watches must not fail silently.
 # Actions pinned to full commit SHAs (F-792); pnpm via pnpm/action-setup +
 # setup-node cache:pnpm (F-787) — same mechanism as main.yml / e2e.yml.
 
@@ -115,7 +119,7 @@ jobs:
             - name: Install dependencies
               run: pnpm install --frozen-lockfile
 
-            - name: Build every storybook statically # zero PR-CI callers — nightly catches build rot
+            - name: Build every storybook statically # also PR-gated in e2e.yml; this copy is unrouted
               run: pnpm run build:storybook
 
     Smoke-Packages:
@@ -445,6 +449,12 @@ jobs:
     Nightly-Status:
         name: Nightly Status Check
         runs-on: ubuntu-latest
+        # issues:write is granted HERE only (the workflow default stays
+        # contents:read) so the single job that files the tracking issue is the
+        # only thing in this file holding a write scope.
+        permissions:
+            contents: read
+            issues: write
         needs:
             [
                 E2E-Full,
@@ -457,16 +467,78 @@ jobs:
             ]
         if: always()
         steps:
+            # Records the verdict WITHOUT exiting, so the reporting step below
+            # still runs; the final step re-raises it. Deliberately not
+            # `if: failure()` + continue-on-error — the test-quality guard bans
+            # continue-on-error in workflows, and it would also mask real errors.
             - name: Check status
+              id: status
               run: |
-                  if [ "${{ needs.E2E-Full.result }}" != "success" ] || \
-                     [ "${{ needs.Storybook-Builds.result }}" != "success" ] || \
-                     [ "${{ needs.Smoke-Packages.result }}" != "success" ] || \
-                     [ "${{ needs.Mastra-Evals.result }}" != "success" ] || \
-                     [ "${{ needs.Drive-Sandbox.result }}" != "success" ] || \
-                     [ "${{ needs.Lighthouse.result }}" != "success" ] || \
-                     [ "${{ needs.Landing-Feedback.result }}" != "success" ]; then
+                  failed=""
+                  record() {
+                    if [ "$2" != "success" ]; then failed="$failed- $1: $2"$'\n'; fi
+                  }
+                  record "E2E-Full" "${{ needs.E2E-Full.result }}"
+                  record "Storybook-Builds" "${{ needs.Storybook-Builds.result }}"
+                  record "Smoke-Packages" "${{ needs.Smoke-Packages.result }}"
+                  record "Mastra-Evals" "${{ needs.Mastra-Evals.result }}"
+                  record "Drive-Sandbox" "${{ needs.Drive-Sandbox.result }}"
+                  record "Lighthouse" "${{ needs.Lighthouse.result }}"
+                  record "Landing-Feedback" "${{ needs.Landing-Feedback.result }}"
+                  if [ -n "$failed" ]; then
                     echo "One or more nightly jobs failed"
-                    exit 1
+                    printf '%s' "$failed"
+                    echo "failed=true" >> "$GITHUB_OUTPUT"
+                    {
+                      echo 'jobs<<NIGHTLY_EOF'
+                      printf '%s' "$failed"
+                      echo 'NIGHTLY_EOF'
+                    } >> "$GITHUB_OUTPUT"
+                  else
+                    echo "All nightly jobs passed"
+                    echo "failed=false" >> "$GITHUB_OUTPUT"
                   fi
-                  echo "All nightly jobs passed"
+
+            # A red nightly used to exit 1 into the void: nobody watches a
+            # scheduled run, which is how the storybook builds stayed broken for
+            # weeks. ONE tracking issue, deduped by the `nightly-failure` label —
+            # comment on the open one if it exists, open it otherwise — so a
+            # month of red nights is a single issue with a comment trail, not
+            # thirty issues.
+            - name: File or update the nightly tracking issue
+              if: steps.status.outputs.failed == 'true'
+              env:
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+                  FAILED_JOBS: ${{ steps.status.outputs.jobs }}
+              run: |
+                  # Idempotent: --force updates the label if it already exists,
+                  # and `gh issue create --label` fails on a label the repo lacks.
+                  gh label create nightly-failure \
+                    --color B60205 \
+                    --description "The scheduled Nightly workflow is failing" \
+                    --force
+
+                  body=$(printf 'The Nightly workflow failed.\n\nFailing jobs:\n\n%s\nRun: %s\n' "$FAILED_JOBS" "$RUN_URL")
+
+                  existing=$(gh issue list \
+                    --label nightly-failure \
+                    --state open \
+                    --limit 1 \
+                    --json number \
+                    --jq '.[0].number // empty')
+
+                  if [ -n "$existing" ]; then
+                    echo "Commenting on the existing tracking issue #$existing"
+                    gh issue comment "$existing" --body "$body"
+                  else
+                    echo "Opening a new tracking issue"
+                    gh issue create \
+                      --title "Nightly is red" \
+                      --label nightly-failure \
+                      --body "$body"
+                  fi
+
+            - name: Re-raise the nightly verdict
+              if: steps.status.outputs.failed == 'true'
+              run: exit 1

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -10,8 +10,10 @@ permissions:
 # unrouted copy as full-breadth coverage. PR routing lives in e2e.yml via
 # scripts/ci/resolve-affected-tests.mjs; nightly always runs everything.
 #
-# A red nightly files/updates a `nightly-failure` tracking issue (Nightly-Status
-# below) — a scheduled run nobody watches must not fail silently.
+# A red nightly files/updates a `nightly-failure` tracking issue and a green one
+# closes it (Nightly-Status below) — a scheduled run nobody watches must not fail
+# silently, and the issue's open/closed state is the signal. Scheduled runs only;
+# a workflow_dispatch reproduce run never touches the issue.
 # Actions pinned to full commit SHAs (F-792); pnpm via pnpm/action-setup +
 # setup-node cache:pnpm (F-787) — same mechanism as main.yml / e2e.yml.
 
@@ -504,9 +506,15 @@ jobs:
             # weeks. ONE tracking issue, deduped by the `nightly-failure` label —
             # comment on the open one if it exists, open it otherwise — so a
             # month of red nights is a single issue with a comment trail, not
-            # thirty issues.
+            # thirty issues. The green arm below then CLOSES it, making the
+            # open/closed transition the signal rather than an endless thread.
+            #
+            # Both arms are restricted to `schedule`: a workflow_dispatch is how
+            # someone REPRODUCES a failure, and a reproduce run must not comment
+            # on (or close) the tracking issue. Consequence worth knowing: the
+            # issue path can only ever be exercised by a real scheduled run.
             - name: File or update the nightly tracking issue
-              if: steps.status.outputs.failed == 'true'
+              if: github.event_name == 'schedule' && steps.status.outputs.failed == 'true'
               env:
                   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
                   RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
@@ -538,6 +546,32 @@ jobs:
                       --label nightly-failure \
                       --body "$body"
                   fi
+
+            # Green arm: close the tracking issue so its OPEN/CLOSED state
+            # tracks nightly's health. No label bootstrap here — if no label
+            # exists there is nothing to find, and `gh issue list` on an unknown
+            # label returns empty rather than failing.
+            - name: Close the nightly tracking issue once nightly is green again
+              if: github.event_name == 'schedule' && steps.status.outputs.failed == 'false'
+              env:
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+              run: |
+                  existing=$(gh issue list \
+                    --label nightly-failure \
+                    --state open \
+                    --limit 1 \
+                    --json number \
+                    --jq '.[0].number // empty')
+
+                  if [ -z "$existing" ]; then
+                    echo "Nightly is green and no tracking issue is open — nothing to do"
+                    exit 0
+                  fi
+
+                  echo "Closing tracking issue #$existing"
+                  gh issue close "$existing" \
+                    --comment "Nightly is green again on $RUN_URL"
 
             - name: Re-raise the nightly verdict
               if: steps.status.outputs.failed == 'true'

--- a/apps/storybook-preact/.storybook/main.ts
+++ b/apps/storybook-preact/.storybook/main.ts
@@ -1,4 +1,5 @@
 import type { StorybookConfig } from '@storybook/preact-vite'
+import { withUpupViteWorkerFormat } from '@upupjs/storybook-config/vite'
 import preact from '@preact/preset-vite'
 
 // We re-apply `@preact/preset-vite` in the preview so its `react -> preact/compat`
@@ -28,7 +29,8 @@ const config: StorybookConfig = {
     async viteFinal(cfg) {
         cfg.plugins = cfg.plugins ?? []
         cfg.plugins.push(preact({ devToolsEnabled: false }))
-        return cfg
+        // Shared: ES worker output for core's module pipeline worker.
+        return withUpupViteWorkerFormat(cfg)
     },
 }
 export default config

--- a/apps/storybook-react/.storybook/main.ts
+++ b/apps/storybook-react/.storybook/main.ts
@@ -1,22 +1,29 @@
 import type { StorybookConfig } from '@storybook/react-vite'
+import { withUpupViteWorkerFormat } from '@upupjs/storybook-config/vite'
 
 const VUE_DEV_URL = 'http://localhost:53051'
 
 const config: StorybookConfig = {
-  framework: '@storybook/react-vite',
-  stories: ['../src/**/*.mdx', '../src/**/*.stories.@(ts|tsx)'],
-  addons: [
-    '@storybook/addon-docs',
-    '@storybook/addon-a11y',
-    '@storybook/addon-themes',
-    'msw-storybook-addon',
-  ],
-  refs: (_config, { configType }) => ({
-    vue: {
-      title: 'Vue',
-      url: configType === 'DEVELOPMENT' ? VUE_DEV_URL : './vue',
-    },
-  }),
+    framework: '@storybook/react-vite',
+    stories: ['../src/**/*.mdx', '../src/**/*.stories.@(ts|tsx)'],
+    addons: [
+        '@storybook/addon-docs',
+        '@storybook/addon-a11y',
+        '@storybook/addon-themes',
+        'msw-storybook-addon',
+    ],
+    refs: (_config, { configType }) => ({
+        vue: {
+            title: 'Vue',
+            url: configType === 'DEVELOPMENT' ? VUE_DEV_URL : './vue',
+        },
+    }),
+    // Shared: ES worker output for core's module pipeline worker — see the
+    // helper's comment. This app currently builds green without it (its
+    // @storybook/react-vite resolves a rolldown-based vite, which tolerates the
+    // default), but the rule is the same one every other vite storybook needs
+    // and a bundler swap must not silently reintroduce the nightly breakage.
+    viteFinal: async config => withUpupViteWorkerFormat(config),
 }
 
 export default config

--- a/apps/storybook-svelte/.storybook/main.ts
+++ b/apps/storybook-svelte/.storybook/main.ts
@@ -1,5 +1,6 @@
 import type { StorybookConfig } from '@storybook/svelte-vite'
 import { svelte } from '@sveltejs/vite-plugin-svelte'
+import { withUpupViteWorkerFormat } from '@upupjs/storybook-config/vite'
 import { mergeConfig } from 'vite'
 
 const config: StorybookConfig = {
@@ -27,10 +28,13 @@ const config: StorybookConfig = {
     // so the only raw .svelte in the graph is @storybook/svelte's own renderer
     // (PreviewRender.svelte etc.). Without the compiler those reach
     // vite:import-analysis untransformed and fail to parse. Register it here.
+    // Shared: ES worker output for core's module pipeline worker.
     viteFinal: async config =>
-        mergeConfig(config, {
-            plugins: [svelte()],
-        }),
+        withUpupViteWorkerFormat(
+            mergeConfig(config, {
+                plugins: [svelte()],
+            }),
+        ),
 }
 
 export default config

--- a/apps/storybook-vanilla/.storybook/main.ts
+++ b/apps/storybook-vanilla/.storybook/main.ts
@@ -1,17 +1,20 @@
 import type { StorybookConfig } from '@storybook/html-vite'
+import { withUpupViteWorkerFormat } from '@upupjs/storybook-config/vite'
 
 const config: StorybookConfig = {
-  framework: {
-    name: '@storybook/html-vite',
-    options: {},
-  },
-  stories: ['../src/**/*.mdx', '../src/**/*.stories.@(ts|tsx)'],
-  addons: [
-    '@storybook/addon-docs',
-    '@storybook/addon-a11y',
-    '@storybook/addon-themes',
-    'msw-storybook-addon',
-  ],
+    framework: {
+        name: '@storybook/html-vite',
+        options: {},
+    },
+    stories: ['../src/**/*.mdx', '../src/**/*.stories.@(ts|tsx)'],
+    addons: [
+        '@storybook/addon-docs',
+        '@storybook/addon-a11y',
+        '@storybook/addon-themes',
+        'msw-storybook-addon',
+    ],
+    // Shared: ES worker output for core's module pipeline worker.
+    viteFinal: async config => withUpupViteWorkerFormat(config),
 }
 
 export default config

--- a/apps/storybook-vue/.storybook/main.ts
+++ b/apps/storybook-vue/.storybook/main.ts
@@ -1,26 +1,28 @@
 import type { StorybookConfig } from '@storybook/vue3-vite'
+import { withUpupViteWorkerFormat } from '@upupjs/storybook-config/vite'
 
 const config: StorybookConfig = {
-  framework: '@storybook/vue3-vite',
-  stories: ['../src/**/*.mdx', '../src/**/*.stories.@(ts|tsx)'],
-  addons: [
-    '@storybook/addon-docs',
-    '@storybook/addon-a11y',
-    '@storybook/addon-themes',
-    'msw-storybook-addon',
-  ],
-  // Vue ships the esm-bundler build, which expects these compile-time feature
-  // flags to be injected by the bundler; without them Vue logs a dev-console
-  // warning. Define them explicitly so the canvas console is clean.
-  viteFinal: async (config) => {
-    config.define = {
-      ...config.define,
-      __VUE_OPTIONS_API__: 'true',
-      __VUE_PROD_DEVTOOLS__: 'false',
-      __VUE_PROD_HYDRATION_MISMATCH_DETAILS__: 'false',
-    }
-    return config
-  },
+    framework: '@storybook/vue3-vite',
+    stories: ['../src/**/*.mdx', '../src/**/*.stories.@(ts|tsx)'],
+    addons: [
+        '@storybook/addon-docs',
+        '@storybook/addon-a11y',
+        '@storybook/addon-themes',
+        'msw-storybook-addon',
+    ],
+    // Vue ships the esm-bundler build, which expects these compile-time feature
+    // flags to be injected by the bundler; without them Vue logs a dev-console
+    // warning. Define them explicitly so the canvas console is clean.
+    viteFinal: async config => {
+        config.define = {
+            ...config.define,
+            __VUE_OPTIONS_API__: 'true',
+            __VUE_PROD_DEVTOOLS__: 'false',
+            __VUE_PROD_HYDRATION_MISMATCH_DETAILS__: 'false',
+        }
+        // Shared: ES worker output for core's module pipeline worker.
+        return withUpupViteWorkerFormat(config)
+    },
 }
 
 export default config

--- a/packages/storybook-config/package.json
+++ b/packages/storybook-config/package.json
@@ -8,6 +8,10 @@
             "types": "./src/index.ts",
             "default": "./src/index.ts"
         },
+        "./vite": {
+            "types": "./src/vite.ts",
+            "default": "./src/vite.ts"
+        },
         "./brand.css": "./src/brand.css"
     },
     "scripts": {

--- a/packages/storybook-config/src/vite.test.ts
+++ b/packages/storybook-config/src/vite.test.ts
@@ -1,0 +1,44 @@
+// src/vite.test.ts
+import { describe, it, expect } from 'vitest'
+import { withUpupViteWorkerFormat } from './vite'
+
+// The helper mutates and returns the SAME object, so these assert on the input
+// they passed in. Annotating the literals (rather than widening the helper's
+// return type) keeps its signature `T -> T`, which is what makes it assignable
+// back to every framework's `StorybookConfig['viteFinal']` return type.
+type TestConfig = {
+    plugins?: unknown[]
+    worker?: { format?: 'es' | 'iife'; plugins?: unknown }
+}
+
+describe('withUpupViteWorkerFormat', () => {
+    it('sets worker.format to es so the code-splitting module worker can build', () => {
+        const config: TestConfig = {}
+        withUpupViteWorkerFormat(config)
+        expect(config.worker?.format).toBe('es')
+    })
+
+    it('overrides an inherited iife worker format rather than deferring to it', () => {
+        const config: TestConfig = { worker: { format: 'iife' } }
+        withUpupViteWorkerFormat(config)
+        expect(config.worker?.format).toBe('es')
+    })
+
+    it('preserves the rest of the worker options and the surrounding config', () => {
+        const plugin = { name: 'existing' }
+        const workerPlugins = () => [plugin]
+        const config: TestConfig = {
+            plugins: [plugin],
+            worker: { plugins: workerPlugins },
+        }
+        withUpupViteWorkerFormat(config)
+        expect(config.plugins).toEqual([plugin])
+        expect(config.worker?.plugins).toBe(workerPlugins)
+        expect(config.worker?.format).toBe('es')
+    })
+
+    it('returns the same object it was handed so a viteFinal hook can return it directly', () => {
+        const config: TestConfig = {}
+        expect(withUpupViteWorkerFormat(config)).toBe(config)
+    })
+})

--- a/packages/storybook-config/src/vite.ts
+++ b/packages/storybook-config/src/vite.ts
@@ -21,6 +21,10 @@ type ViteConfigWithWorker = {
 /**
  * Force ES output for worker bundles.
  *
+ * MUTATES the config it is given and returns that same object (never a copy),
+ * so a `viteFinal` hook can either return the result or ignore it — the config
+ * it was handed is already updated either way.
+ *
  * `@upupjs/core`'s pipeline worker is a MODULE worker — `runtime/browser.ts`
  * spawns it as `new Worker(new URL('./pipeline-worker.js', import.meta.url),
  * { type: 'module' })` — and vite's `vite:worker-import-meta-url` plugin picks

--- a/packages/storybook-config/src/vite.ts
+++ b/packages/storybook-config/src/vite.ts
@@ -1,0 +1,43 @@
+// Shared Vite tweaks for the storybook apps. One file, six consumers — a
+// per-app copy of any rule here is a defect (same rule as tailwind-config).
+//
+// Typed structurally rather than against vite's own `UserConfig`: this package
+// deliberately has no vite dependency (its other modules are browser-side story
+// helpers), and `viteFinal` hands us a config object whose shape we only need
+// to narrow, not reconstruct. The generic passes the caller's own config type
+// straight back, so each framework's `StorybookConfig['viteFinal']` return type
+// still checks.
+
+type ViteWorkerOptions = {
+    format?: 'es' | 'iife'
+    [option: string]: unknown
+}
+
+type ViteConfigWithWorker = {
+    worker?: ViteWorkerOptions
+    [option: string]: unknown
+}
+
+/**
+ * Force ES output for worker bundles.
+ *
+ * `@upupjs/core`'s pipeline worker is a MODULE worker — `runtime/browser.ts`
+ * spawns it as `new Worker(new URL('./pipeline-worker.js', import.meta.url),
+ * { type: 'module' })` — and vite's `vite:worker-import-meta-url` plugin picks
+ * that `new URL(...)` up out of core's built dist and bundles the worker as its
+ * own rollup build. Vite's default `worker.format` is `'iife'`, and a worker
+ * graph that code-splits (core's does: the pipeline steps are dynamic imports)
+ * cannot be emitted as IIFE, so a production `storybook build` dies with
+ * "Invalid value \"iife\" for option \"worker.format\"". `'es'` both permits the
+ * split and matches the `type: 'module'` the runtime actually requests.
+ *
+ * Dev-mode storybook never hits this — only the code-splitting production build
+ * does, which is why this stayed invisible to every PR gate until the nightly
+ * static builds were promoted into e2e.yml.
+ */
+export function withUpupViteWorkerFormat<T extends ViteConfigWithWorker>(
+    config: T,
+): T {
+    config.worker = { ...config.worker, format: 'es' }
+    return config
+}

--- a/scripts/ci/resolve-affected-tests.mjs
+++ b/scripts/ci/resolve-affected-tests.mjs
@@ -181,7 +181,11 @@ export const IMPACT_RULES = [
         test: path => FRAMEWORK_UI.test(path),
     },
     {
-        name: 'storybook',
+        // Named for the PARITY harness, not the static builds — the
+        // `storybook-build` rule below owns those. Keeping both bare
+        // `storybook` would make a combined reason read "(storybook+
+        // storybook-build)", which says nothing about why either fired.
+        name: 'storybook-parity',
         tier: TIER.TARGETED,
         suites: ['e2e'],
         test: path =>

--- a/scripts/ci/resolve-affected-tests.mjs
+++ b/scripts/ci/resolve-affected-tests.mjs
@@ -11,6 +11,11 @@
  *             secret-less, boots the landing app and drives /docs. On for a
  *             change to the landing app (incl. content/docs), the landing e2e
  *             harness, or any package the landing app consumes.
+ *   storybook — the six static `storybook build` productions (Storybook-Builds).
+ *             Browser-less and MinIO-less, but a genuine production
+ *             code-splitting build, which dev-mode storybook is NOT — the class
+ *             of defect it catches (a vite worker.format failure originating in
+ *             @upupjs/core's dist) is invisible to every other suite.
  *
  * Fail-open is the core safety property: a path that matches no rule runs
  * EVERYTHING. An unknown/new directory can never silently skip coverage.
@@ -27,8 +32,8 @@
  *       Force every suite (workflow_dispatch / manual re-run).
  *   --json   Emit {suites, reasons, changedFiles} to stdout; no side effects.
  *
- * Default (non-json) output appends `e2e|minio|smoke|docsE2e=true|false` to the
- * file at $GITHUB_OUTPUT (when set), appends a markdown table to $GITHUB_STEP_SUMMARY
+ * Default (non-json) output appends `e2e|minio|smoke|docsE2e|storybook=true|false`
+ * to the file at $GITHUB_OUTPUT (when set), appends a markdown table to $GITHUB_STEP_SUMMARY
  * (when set), and always prints a human-readable per-suite reason table.
  *
  * Exit 0 in every resolved case (empty diff included → all suites false).
@@ -43,9 +48,10 @@ import { parseArgs } from 'node:util'
 
 // ── Suites ───────────────────────────────────────────────────────────────
 
-/** The routable suites, in stable display order. `docsE2e` is the cheap docs
- * job; the other three are the heavy MinIO/cross-framework/tarball suites. */
-export const SUITES = ['e2e', 'minio', 'smoke', 'docsE2e']
+/** The routable suites, in stable display order. `docsE2e` and `storybook` are
+ * the cheap jobs; the other three are the heavy MinIO/cross-framework/tarball
+ * suites. */
+export const SUITES = ['e2e', 'minio', 'smoke', 'docsE2e', 'storybook']
 
 // ── Tiers & precedence ───────────────────────────────────────────────────
 //
@@ -232,6 +238,32 @@ export const IMPACT_RULES = [
             path.startsWith('packages/interactive-example/'),
     },
 
+    {
+        // A static `storybook build` compiles apps/storybook-*/ against the
+        // BUILT dist of every framework package it renders, so any of those can
+        // break it — @upupjs/core did, via the module pipeline worker vite emits
+        // out of core's dist (the worker.format defect that kept nightly red for
+        // weeks while every PR gate stayed green). TARGETED with a lone
+        // `storybook` suite, mirroring docs-e2e: it unions on top of whatever
+        // heavy suites these same files already carry, so every pre-existing
+        // verdict is byte-identical. The shared factories (tailwind-config owns
+        // the postcss/fx layer all six render; storybook-config owns their
+        // shared vite tweaks) are UNIVERSAL and include it for free, as does
+        // fail-open. Docs-only changes stay light and skip it.
+        //
+        // Reusing FRAMEWORK_UI deliberately over-includes @upupjs/next, which
+        // backs no storybook: one shared regex beats a second near-duplicate,
+        // and over-running a browser-less build job errs in the safe direction.
+        name: 'storybook-build',
+        tier: TIER.TARGETED,
+        suites: ['storybook'],
+        test: path =>
+            path.startsWith('apps/storybook-') ||
+            path.startsWith('packages/storybook-config/') ||
+            path.startsWith('packages/core/') ||
+            FRAMEWORK_UI.test(path),
+    },
+
     // ── LIGHT_DIR → NONE (dev-only apps + repo metadata) ─────────────────
     {
         // apps/landing/ also covers the docs (MDX under content/docs, served
@@ -386,7 +418,7 @@ function formatReasonTable(result) {
     const lines = ['Affected test suites (feeds e2e.yml Resolve-Affected):']
     for (const suite of SUITES) {
         const decision = result.suites[suite] ? 'RUN ' : 'SKIP'
-        lines.push(`  ${suite.padEnd(6)} ${decision}  ${result.reasons[suite]}`)
+        lines.push(`  ${suite.padEnd(9)} ${decision}  ${result.reasons[suite]}`)
     }
     if (result.forcedAll) {
         lines.push('')

--- a/scripts/ci/resolve-affected-tests.test.mjs
+++ b/scripts/ci/resolve-affected-tests.test.mjs
@@ -35,34 +35,34 @@ function runCli(args, env = {}, cwd) {
 
 const TARGETED_CASES = [
     {
-        name: 'a core src change triggers e2e, minio, smoke, and docsE2e because every heavy suite consumes @upupjs/core and the landing docs demo is built from it',
+        name: 'a core src change triggers every suite because each one consumes @upupjs/core — the heavy suites, the landing docs demo, and the static storybook builds that bundle its dist',
         path: 'packages/core/src/upload/pipeline.ts',
-        suites: ['e2e', 'minio', 'smoke', 'docsE2e'],
+        suites: ['e2e', 'minio', 'smoke', 'docsE2e', 'storybook'],
     },
     {
-        name: 'a server src change triggers e2e, minio, smoke, and docsE2e because its integration tests need real MinIO and the landing app consumes @upupjs/server',
+        name: 'a server src change triggers e2e, minio, smoke, and docsE2e but not storybook because its integration tests need real MinIO, the landing app consumes @upupjs/server, and no storybook renders it',
         path: 'packages/server/src/handler.ts',
         suites: ['e2e', 'minio', 'smoke', 'docsE2e'],
     },
     {
-        name: 'a react UI change triggers e2e, smoke, and docsE2e but not minio because a UI port needs no storage backend and the landing docs demo renders @upupjs/react',
+        name: 'a react UI change triggers e2e, smoke, docsE2e, and storybook but not minio because a UI port needs no storage backend while the landing docs demo and the react storybook both render it',
         path: 'packages/react/src/UpupUploader.tsx',
-        suites: ['e2e', 'smoke', 'docsE2e'],
+        suites: ['e2e', 'smoke', 'docsE2e', 'storybook'],
     },
     {
-        name: 'a next package change triggers e2e and smoke because it re-exports the UI and ships route handlers',
+        name: 'a next package change triggers e2e, smoke, and storybook because it re-exports the UI and ships route handlers, and the shared framework-UI rule deliberately over-includes it in the cheap build job',
         path: 'packages/next/src/server/app-router.ts',
-        suites: ['e2e', 'smoke'],
+        suites: ['e2e', 'smoke', 'storybook'],
     },
     {
-        name: 'a storybook-config change triggers only e2e because it feeds the parity harness, not uploads',
+        name: 'a storybook-config change triggers e2e and storybook because it feeds both the parity harness and the six static builds, but no upload path',
         path: 'packages/storybook-config/src/preview.ts',
-        suites: ['e2e'],
+        suites: ['e2e', 'storybook'],
     },
     {
-        name: 'a storybook app change triggers only e2e because it is a cross-framework parity project',
+        name: 'a storybook app change triggers e2e and storybook because it is both a cross-framework parity project and a statically built site',
         path: 'apps/storybook-vue/.storybook/main.ts',
-        suites: ['e2e'],
+        suites: ['e2e', 'storybook'],
     },
     {
         name: 'an e2e-test harness change triggers e2e and minio because the Playwright suite drives real uploads',
@@ -107,7 +107,7 @@ for (const testCase of TARGETED_CASES) {
     })
 }
 
-test('every non-react framework UI package triggers exactly e2e and smoke because the parity harness and tarball consumer both exercise it, while react additionally triggers docsE2e because the landing docs demo consumes it', () => {
+test('every non-react framework UI package triggers exactly e2e, smoke, and storybook because the parity harness, tarball consumer, and static storybook builds all exercise it, while react additionally triggers docsE2e because the landing docs demo consumes it', () => {
     for (const framework of [
         'vue',
         'svelte',
@@ -119,16 +119,17 @@ test('every non-react framework UI package triggers exactly e2e and smoke becaus
         const resolved = resolveFile(`packages/${framework}/src/index.ts`)
         assert.deepEqual(
             resolved.suites,
-            ['e2e', 'smoke'],
-            `expected ${framework} to route to e2e+smoke`,
+            ['e2e', 'smoke', 'storybook'],
+            `expected ${framework} to route to e2e+smoke+storybook`,
         )
     }
     // react is the sole UI framework the landing app depends on, so its change
-    // adds the docs suite on top of the shared e2e+smoke routing.
+    // adds the docs suite on top of the shared e2e+smoke+storybook routing.
     assert.deepEqual(resolveFile('packages/react/src/index.ts').suites, [
         'e2e',
         'smoke',
         'docsE2e',
+        'storybook',
     ])
 })
 
@@ -193,7 +194,13 @@ for (const testCase of UNIVERSAL_CASES) {
     test(testCase.name, () => {
         const resolved = resolveFile(testCase.path)
         assert.equal(resolved.tier, 'universal')
-        assert.deepEqual(resolved.suites, ['e2e', 'minio', 'smoke', 'docsE2e'])
+        assert.deepEqual(resolved.suites, [
+            'e2e',
+            'minio',
+            'smoke',
+            'docsE2e',
+            'storybook',
+        ])
     })
 }
 
@@ -276,11 +283,63 @@ test('a landing e2e harness change routes to e2e, minio, and docsE2e because it 
 test('the landing playwright config is universal so it forces every suite including docsE2e, because a config change invalidates all routing', () => {
     const resolved = resolveFile('apps/e2e-test/playwright.landing.config.ts')
     assert.equal(resolved.tier, 'universal')
-    assert.deepEqual(resolved.suites, ['e2e', 'minio', 'smoke', 'docsE2e'])
+    assert.deepEqual(resolved.suites, [
+        'e2e',
+        'minio',
+        'smoke',
+        'docsE2e',
+        'storybook',
+    ])
 })
 
 test('a landing README stays fully light because the markdown carve-out outranks the docs-e2e rule and a readme cannot regress the rendered docs', () => {
     assert.deepEqual(resolveFile('apps/landing/README.md').suites, [])
+})
+
+// ── resolveFile: storybook-build routing ───────────────────────────────────
+
+test('every app that owns a storybook routes to the storybook suite, because a static build compiles each one against its framework package', () => {
+    for (const framework of [
+        'react',
+        'vue',
+        'svelte',
+        'vanilla',
+        'angular',
+        'preact',
+    ]) {
+        const resolved = resolveFile(
+            `apps/storybook-${framework}/.storybook/main.ts`,
+        )
+        assert.equal(resolved.tier, 'targeted')
+        assert.ok(
+            resolved.suites.includes('storybook'),
+            `expected apps/storybook-${framework} to route to the storybook suite`,
+        )
+    }
+})
+
+test('the shared tailwind factory forces the storybook suite through the universal tier, because all six storybooks render its postcss/fx layer', () => {
+    const resolved = resolveFile('packages/tailwind-config/postcss.cjs')
+    assert.equal(resolved.tier, 'universal')
+    assert.ok(resolved.suites.includes('storybook'))
+})
+
+test('a server-only change skips the storybook suite, because no storybook renders @upupjs/server and the static builds never reach a backend', () => {
+    assert.equal(
+        resolveFile('packages/server/src/upload-routes.ts').suites.includes(
+            'storybook',
+        ),
+        false,
+    )
+})
+
+test('a landing docs change skips the storybook suite, so a docs-only PR does not pay for six production builds', () => {
+    assert.equal(
+        resolveFile('apps/landing/content/docs/react.mdx').suites.includes(
+            'storybook',
+        ),
+        false,
+    )
 })
 
 // ── resolveFile: precedence subtleties ─────────────────────────────────────
@@ -288,7 +347,13 @@ test('a landing README stays fully light because the markdown carve-out outranks
 test('a config basename outranks the package rule so a package vitest config still runs everything', () => {
     const resolved = resolveFile('packages/svelte/vitest.config.ts')
     assert.equal(resolved.tier, 'universal')
-    assert.deepEqual(resolved.suites, ['e2e', 'minio', 'smoke', 'docsE2e'])
+    assert.deepEqual(resolved.suites, [
+        'e2e',
+        'minio',
+        'smoke',
+        'docsE2e',
+        'storybook',
+    ])
 })
 
 test('the markdown carve-out outranks a directory-targeted rule so a package README skips every suite', () => {
@@ -300,19 +365,32 @@ test('the markdown carve-out outranks a directory-targeted rule so a package REA
 test('a universal shared factory outranks the markdown carve-out so its README still runs everything', () => {
     const resolved = resolveFile('packages/eslint-config/README.md')
     assert.equal(resolved.tier, 'universal')
-    assert.deepEqual(resolved.suites, ['e2e', 'minio', 'smoke', 'docsE2e'])
+    assert.deepEqual(resolved.suites, [
+        'e2e',
+        'minio',
+        'smoke',
+        'docsE2e',
+        'storybook',
+    ])
 })
 
 test("a package's own package.json routes to that package's targeted suites, because only the ROOT manifest is universal", () => {
     // react is a landing dep, so its package.json unions docsE2e onto the
-    // framework-ui e2e+smoke routing.
+    // framework-ui e2e+smoke routing, and storybook-build adds the static
+    // builds on top.
     const pkg = resolveFile('packages/react/package.json')
     assert.equal(pkg.tier, 'targeted')
-    assert.deepEqual(pkg.suites, ['e2e', 'smoke', 'docsE2e'])
+    assert.deepEqual(pkg.suites, ['e2e', 'smoke', 'docsE2e', 'storybook'])
 
     const root = resolveFile('package.json')
     assert.equal(root.tier, 'universal')
-    assert.deepEqual(root.suites, ['e2e', 'minio', 'smoke', 'docsE2e'])
+    assert.deepEqual(root.suites, [
+        'e2e',
+        'minio',
+        'smoke',
+        'docsE2e',
+        'storybook',
+    ])
 })
 
 // ── resolveFile: fail-open ─────────────────────────────────────────────────
@@ -320,13 +398,25 @@ test("a package's own package.json routes to that package's targeted suites, bec
 test('an unmatched novel package path fails open to every suite so a new directory can never silently skip coverage', () => {
     const resolved = resolveFile('packages/brand-new-thing/src/index.ts')
     assert.equal(resolved.tier, 'fail-open')
-    assert.deepEqual(resolved.suites, ['e2e', 'minio', 'smoke', 'docsE2e'])
+    assert.deepEqual(resolved.suites, [
+        'e2e',
+        'minio',
+        'smoke',
+        'docsE2e',
+        'storybook',
+    ])
 })
 
 test('an unmatched novel root file fails open to every suite because an unknown path is treated as high risk', () => {
     const resolved = resolveFile('renovate.toml')
     assert.equal(resolved.tier, 'fail-open')
-    assert.deepEqual(resolved.suites, ['e2e', 'minio', 'smoke', 'docsE2e'])
+    assert.deepEqual(resolved.suites, [
+        'e2e',
+        'minio',
+        'smoke',
+        'docsE2e',
+        'storybook',
+    ])
 })
 
 // ── resolveAffected: changeset behavior ────────────────────────────────────
@@ -338,6 +428,7 @@ test('an empty diff runs no suite because there is nothing to verify', () => {
         minio: false,
         smoke: false,
         docsE2e: false,
+        storybook: false,
     })
     for (const suite of SUITES) {
         assert.equal(result.reasons[suite], 'no changed files')
@@ -351,6 +442,7 @@ test('the force-all flag runs every suite because a manual dispatch opts out of 
         minio: true,
         smoke: true,
         docsE2e: true,
+        storybook: true,
     })
     for (const suite of SUITES) {
         assert.equal(
@@ -371,10 +463,11 @@ test('a mixed changeset unions suites across files so a docs tweak beside a core
         minio: true,
         smoke: true,
         docsE2e: true,
+        storybook: true,
     })
 })
 
-test('a docs-content-only changeset runs docsE2e alone, skipping every heavy suite because MDX under the landing app touches no upload path', () => {
+test('a docs-content-only changeset runs docsE2e alone, skipping every heavy suite and the storybook builds because MDX under the landing app touches no upload path and no storybook renders it', () => {
     const result = resolveAffected([
         'apps/landing/content/docs/getting-started.mdx',
         'apps/landing/src/components/docs/DocsSearch.tsx',
@@ -384,10 +477,15 @@ test('a docs-content-only changeset runs docsE2e alone, skipping every heavy sui
         minio: false,
         smoke: false,
         docsE2e: true,
+        storybook: false,
     })
     assert.match(result.reasons.docsE2e, /apps\/landing/)
     assert.equal(
         result.reasons.e2e,
+        'skipped — no changed file affects this suite',
+    )
+    assert.equal(
+        result.reasons.storybook,
         'skipped — no changed file affects this suite',
     )
 })
@@ -399,6 +497,7 @@ test('a changeset of only light files runs no suite because none of them affect 
         minio: false,
         smoke: false,
         docsE2e: false,
+        storybook: false,
     })
     for (const suite of SUITES) {
         assert.equal(
@@ -408,13 +507,14 @@ test('a changeset of only light files runs no suite because none of them affect 
     }
 })
 
-test('a non-react UI-only changeset runs e2e and smoke but skips minio and docsE2e, because vue is not a landing dependency', () => {
+test('a non-react UI-only changeset runs e2e, smoke, and storybook but skips minio and docsE2e, because vue backs a storybook but is not a landing dependency and needs no storage backend', () => {
     const result = resolveAffected(['packages/vue/src/UpupUploader.vue'])
     assert.deepEqual(result.suites, {
         e2e: true,
         minio: false,
         smoke: true,
         docsE2e: false,
+        storybook: true,
     })
     assert.match(result.reasons.e2e, /packages\/vue/)
     assert.equal(
@@ -438,6 +538,7 @@ test('an unmatched file is recorded in the fail-open list so reviewers can see c
         minio: true,
         smoke: true,
         docsE2e: true,
+        storybook: true,
     })
 })
 
@@ -479,6 +580,7 @@ test('the CLI writes GitHub Actions outputs to GITHUB_OUTPUT so the workflow can
     assert.match(written, /^minio=true$/m)
     assert.match(written, /^smoke=true$/m)
     assert.match(written, /^docsE2e=true$/m)
+    assert.match(written, /^storybook=true$/m)
 })
 
 test('the CLI records false outputs for a light-only changeset so a skipped suite is explicit, not absent', () => {
@@ -492,8 +594,10 @@ test('the CLI records false outputs for a light-only changeset so a skipped suit
     assert.match(written, /^e2e=true$/m)
     assert.match(written, /^minio=false$/m)
     assert.match(written, /^smoke=true$/m)
-    // react is a landing dep → the docs suite is emitted true alongside.
+    // react is a landing dep → the docs suite is emitted true alongside, and
+    // the react storybook renders it → so is the static-build suite.
     assert.match(written, /^docsE2e=true$/m)
+    assert.match(written, /^storybook=true$/m)
 })
 
 test('the CLI emits a parseable JSON document under --json so other tooling can consume the routing decision', () => {
@@ -505,6 +609,7 @@ test('the CLI emits a parseable JSON document under --json so other tooling can 
         minio: false,
         smoke: true,
         docsE2e: false,
+        storybook: true,
     })
     assert.equal(typeof parsed.reasons.e2e, 'string')
     assert.deepEqual(parsed.changedFiles, ['packages/svelte/src/x.ts'])
@@ -527,6 +632,7 @@ test('the CLI accepts comma-joined files in a single flag so a workflow can pass
         minio: true,
         smoke: true,
         docsE2e: true,
+        storybook: true,
     })
 })
 
@@ -583,6 +689,7 @@ test('the CLI forces every suite under --all so a manual re-run can bypass routi
         minio: true,
         smoke: true,
         docsE2e: true,
+        storybook: true,
     })
 })
 
@@ -638,6 +745,7 @@ test('the CLI computes an affected set from real git history so the git-diff pat
             minio: true,
             smoke: true,
             docsE2e: true,
+            storybook: true,
         })
     } finally {
         rmSync(repo, { recursive: true, force: true, maxRetries: 3 })


### PR DESCRIPTION
## Summary

Promotes PR #349 (reviewed APPROVE-WITH-NITS, all findings applied, 17/17 checks green) from dev to master:

- **Root-cause fix:** `@upupjs/core`'s pipeline worker is a module worker whose code-split graph cannot be expressed by vite's default `worker.format: 'iife'` in production storybook builds. New shared `@upupjs/storybook-config/vite` helper (`withUpupViteWorkerFormat`) applied across all five vite-based storybooks — this un-reds the Nightly "Static storybook builds" job that has failed since at least 2026-07-19 (4/6 frameworks affected).
- **PR-gates the static storybook builds** in e2e.yml via a new resolver suite (`storybook`), proven byte-identical for all pre-existing verdicts; rollup fails on unsanctioned skips. The job already passed twice on PR #349's own runs.
- **Loud nightly failures:** scheduled-run rollup now files/updates a single `nightly-failure` tracking issue on red and closes it on the next green (job-scoped `issues: write`); manual dispatches exempt.

## Test plan
- [x] All six `build-storybook` exit 0 locally + new CI job green twice on ubuntu
- [x] Served built storybooks, drove stories in Chromium, verified ES worker chunk mechanism
- [x] test:scripts 135/135, test:quality clean, resolver equivalence proven over 1570-file corpus
- [ ] PR CI rollups green before merge
- [ ] Tonight's scheduled nightly goes green end-to-end