### PR TITLE
fix(core): Firefox reload-resume stall — materialize part bodies, cache the crash-recovery IndexedDB connection

### DIFF
--- a/.changeset/firm-parts-bytes.md
+++ b/.changeset/firm-parts-bytes.md
@@ -1,0 +1,20 @@
+---
+'@upupjs/core': patch
+---
+
+Multipart part PUTs now materialize each slice to an ArrayBuffer before
+`xhr.send`, instead of handing XHR a lazy Blob reference. Firefox streams Blob
+bodies lazily during send, and when the Blob is a slice of a File revived from
+IndexedDB after a page reload (crash-recovery resume), that lazy read could
+stall — headers went out, the body never followed, and the storage backend
+timed the part out as a 503 storm. Reading the bytes up front turns a broken
+source into a clean, retryable failure: a read rejection (e.g. Firefox
+`NotReadableError`) burns one `retryDelays` slot and re-reads the slice fresh,
+a read that never settles is cut off by its own `partTimeoutMs` deadline
+(a separate window from the PUT's inactivity watchdog, which starts fresh
+after the read), and aborting the upload cancels an in-flight read
+immediately. Materialization is capped at 16 MiB per part — larger parts
+(part size scales with file size past ~48 GiB via the 10,000-part clamp) keep
+the streaming Blob path, so transient memory is bounded by
+`maxConcurrentParts × min(partSize, 16 MiB)` (plus XHR's own copy of the
+buffer while sending).

--- a/.changeset/open-blob-doors.md
+++ b/.changeset/open-blob-doors.md
@@ -1,0 +1,15 @@
+---
+'@upupjs/core': patch
+---
+
+`IndexedDBStorage` (crash recovery) now holds one cached IndexedDB connection
+for its lifetime instead of opening and closing the database around every
+operation. Firefox ties Blob/File handles read from IndexedDB to the
+connection they were read over: closing it right after the crash-recovery
+restore invalidated the revived File's backing store, and mid-resume slice
+reads rejected with `AbortError` — a Firefox-only reload-resume stall
+(Chromium materializes IndexedDB blobs independently and was unaffected).
+Keeping the connection open keeps the revived File readable for the whole
+resume. The cached connection still yields to the rest of the browser: a
+`versionchange` (e.g. `deleteDatabase` from another tab) closes and releases
+it, and a browser-initiated `close` makes the next operation reopen cleanly.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -346,6 +346,20 @@ the suites actually drive):
   variant fixture block, (c) a manual live overflow **and spacing/touch-target**
   check per framework (the harness catches outright clip, never cramped
   spacing).
+- **Firefox-only upload behavior:** the e2e harness is Chromium-only, and two
+  proven Firefox-only reload-resume bugs (2026-08-21) are invisible to it by
+  construction: Firefox streams XHR Blob bodies lazily (a slice of an
+  IndexedDB-revived File can send headers but never the body → backend 503
+  storm), and Firefox ties Blob/File handles read from IndexedDB to the
+  connection they were read over (closing the db invalidates a revived File
+  mid-resume; `arrayBuffer()` rejects `AbortError`). Guards: the vitest
+  suites `multipart-part-body-materialization.test.ts` and
+  `crash-recovery-indexeddb-connection.test.ts` pin the fix mechanisms
+  (materialize parts ≤ 16 MiB; one cached IDB connection), but only a live
+  Firefox run against real/slow storage (B2, or MinIO under load — fast local
+  MinIO often passes) proves the behavior itself. Re-verify there before
+  touching `putPart` body handling or `IndexedDBStorage`'s connection
+  lifecycle.
 
 ## Naming vocabulary
 

--- a/apps/landing/content/docs/resumable-uploads.mdx
+++ b/apps/landing/content/docs/resumable-uploads.mdx
@@ -65,7 +65,7 @@ Seven fields, all optional.
 | `chunkSizeBytes`     | `number`   | `5242880` (5 MiB)       | Requested part size. A fallback only — see [Part size](#part-size-the-5-mib-floor-and-the-10000-part-cap), the server decides the real value.                                                                                                                                       |
 | `persist`            | `boolean`  | `true`                  | Keep a per-file session in `localStorage` so an interrupted upload resumes at the last completed part — see [Cross-reload resume](#cross-reload-resume). `false` restores the older behavior: any failure aborts the server-side upload and the next attempt starts from byte zero. |
 | `retryDelays`        | `number[]` | `[0, 1000, 3000, 5000]` | Backoff schedule, in milliseconds, for retrying a transiently failed or stalled part — the same vocabulary tus uses. The array's length is the retry budget; `[]` disables part retries. See [Part retries](#part-retries-and-the-stall-watchdog).                                  |
-| `partTimeoutMs`      | `number`   | `180000` (3 min)        | Watchdog for one part attempt: a sign or PUT request that neither succeeds nor fails within this window is aborted and retried instead of hanging the upload forever.                                                                                                               |
+| `partTimeoutMs`      | `number`   | `180000` (3 min)        | Watchdog budget for each phase of a part attempt (sign, source read, PUT): a phase that neither succeeds nor fails within its window is aborted and retried instead of hanging the upload forever — see [Part retries](#part-retries-and-the-stall-watchdog).                       |
 | `maxConcurrentParts` | `number`   | `3`                     | How many parts of a single file upload at once — see [Part concurrency](#part-concurrency).                                                                                                                                                                                         |
 | `autoResume`         | `boolean`  | `false`                 | Continue a crash-restored upload automatically instead of waiting for the Resume click — see [The full reload story](#the-full-reload-story-persist--crashrecovery).                                                                                                                |
 
@@ -74,7 +74,10 @@ Seven fields, all optional.
 `maxConcurrentParts` sets how many parts of one file are in flight at the same
 time. Three is a deliberate middle: raising it fills a high-bandwidth link
 faster, and costs memory and sockets, because every in-flight part holds its
-own chunk of the file in the request body. Lower it when your users upload from
+own chunk of the file in memory — parts up to 16 MiB are read into an
+`ArrayBuffer` before the PUT (so each in-flight part costs up to
+`min(partSize, 16 MiB)` of resident bytes, plus the copy XHR makes while
+sending), and larger parts stream from the file. Lower it when your users upload from
 constrained devices or you are being rate-limited; raise it when big files
 crawl on connections you know are fast. Values below `1` are clamped to `1`.
 
@@ -84,14 +87,17 @@ each is twelve requests in flight.
 
 ### Part retries and the stall watchdog
 
-Every part attempt runs under a watchdog. It is an **inactivity** timer, not a
+Every part attempt runs under a watchdog, applied to each of its phases
+separately: the sign call, the source read (for parts small enough to be
+materialized), and the PUT. For the PUT it is an **inactivity** timer, not a
 deadline on the whole transfer: as long as bytes keep moving, a part is never
 timed out, no matter how slow the link or how large the part. The watchdog only
 fires after `partTimeoutMs` of **no upload progress at all** — a genuinely
 stalled or dead connection — at which point the attempt is aborted and retried
-rather than hanging for the lifetime of a half-open TCP socket. The sign call,
-which has no progress to measure, is bounded by the same timeout as a plain
-deadline. The 3-minute default suits almost everyone; raise it only if your
+rather than hanging for the lifetime of a half-open TCP socket. The sign call
+and the source read, which have no progress to measure, are each bounded by the
+same timeout as a plain deadline — so the worst case for one attempt is up to
+three windows, not one. The 3-minute default suits almost everyone; raise it only if your
 users sit behind proxies that buffer a whole part before forwarding it (so no
 progress is visible mid-part), and lower it if you want a dead connection
 declared failed sooner.

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -50,6 +50,10 @@ export class UpupCore {
     private _status: UploadStatus = UploadStatus.IDLE
     private _error: Error | null = null
     private crashRecovery: CrashRecoveryManager | null = null
+    // Only set when WE created the IndexedDBStorage (not user-supplied
+    // storage, whose lifecycle belongs to the caller) so destroy() can
+    // release its cached IndexedDB connection.
+    private crashRecoveryStorage: IndexedDBStorage | null = null
     private crashRecoveryUnsubscribe: (() => void) | null = null
     /** Every crash-recovery storage write flows through this one promise chain.
      *  Blob snapshots of large files make IndexedDB puts slow; fire-and-forget
@@ -211,9 +215,12 @@ export class UpupCore {
 
         const crashOptions =
             typeof crashRecovery === 'object' ? crashRecovery : {}
-        this.crashRecovery = new CrashRecoveryManager(
-            crashOptions.storage ?? new IndexedDBStorage(),
-        )
+        let storage = crashOptions.storage
+        if (!storage) {
+            this.crashRecoveryStorage = new IndexedDBStorage()
+            storage = this.crashRecoveryStorage
+        }
+        this.crashRecovery = new CrashRecoveryManager(storage)
         this.crashRecoveryUnsubscribe = this.on('state-change', () => {
             if (this.destroyed || this.files.size === 0) return
             this.queueCrashRecoverySync()
@@ -1152,6 +1159,10 @@ export class UpupCore {
         // Release the manager refs (F-148). Do NOT clear crash-recovery storage — a normal
         // unmount must leave a recoverable snapshot behind. fileManager is deliberately kept
         // (not nulled) so the files/progress getters keep working post-destroy.
+        // Closing the cached IndexedDB connection only releases the handle
+        // (pending transactions drain first); the snapshot data stays put.
+        this.crashRecoveryStorage?.close()
+        this.crashRecoveryStorage = null
         this.crashRecovery = null
         this.pipelineEngine = null
         this.fileOverrides.clear()

--- a/packages/core/src/crash-recovery.ts
+++ b/packages/core/src/crash-recovery.ts
@@ -34,24 +34,77 @@ export class CrashRecoveryManager {
 export class IndexedDBStorage implements PersistentStorage {
     private dbName: string
     private storeName = 'upup-store'
+    /** ONE cached connection for the storage's lifetime — never closed after
+     *  an operation. Firefox ties Blob/File handles read from IndexedDB to
+     *  the connection they were read over: with the old open-per-operation /
+     *  close-on-complete lifecycle, the File revived by the crash-recovery
+     *  restore lost its backing store shortly after the restore's transaction
+     *  closed, and mid-resume slice reads rejected with AbortError ("The
+     *  operation was aborted") — a Firefox-only reload-resume stall reproduced
+     *  against both MinIO and Backblaze B2 (Chromium materializes IndexedDB
+     *  blobs independently of the connection and never failed). The cache
+     *  still yields: `versionchange` (a deleteDatabase/upgrade elsewhere)
+     *  closes and drops it so the other context is never blocked, and a
+     *  browser-initiated `close` drops it so the next operation reopens. */
+    private dbPromise: Promise<IDBDatabase> | null = null
 
     constructor(dbName = 'upup-crash-recovery') {
         this.dbName = dbName
     }
 
-    private async getDB(): Promise<IDBDatabase> {
-        return new Promise((resolve, reject) => {
+    private getDB(): Promise<IDBDatabase> {
+        if (this.dbPromise) return this.dbPromise
+        // The handlers below only clear `dbPromise` when it still points at
+        // THIS open (identity check): a stale connection's late `close`/
+        // `versionchange` must not wipe out a newer connection's cache.
+        const promise = new Promise<IDBDatabase>((resolve, reject) => {
             const request = indexedDB.open(this.dbName, 1)
             request.onupgradeneeded = () => {
                 request.result.createObjectStore(this.storeName)
             }
             request.onsuccess = () => {
-                resolve(request.result)
+                const db = request.result
+                db.onversionchange = () => {
+                    db.close()
+                    if (this.dbPromise === promise) {
+                        this.dbPromise = null
+                    }
+                }
+                db.onclose = () => {
+                    if (this.dbPromise === promise) {
+                        this.dbPromise = null
+                    }
+                }
+                resolve(db)
             }
             request.onerror = () => {
+                if (this.dbPromise === promise) {
+                    this.dbPromise = null
+                }
                 reject(request.error ?? new Error('IndexedDB open failed'))
             }
         })
+        this.dbPromise = promise
+        return promise
+    }
+
+    /** Close and release the cached connection. Safe at any time — the next
+     *  operation reopens. `UpupCore.destroy()` calls this so an unmounted
+     *  uploader doesn't keep the database held open (pending transactions
+     *  still drain first per the IndexedDB spec, so a queued snapshot write
+     *  is never cut off mid-transaction). */
+    close(): void {
+        const promise = this.dbPromise
+        if (!promise) return
+        this.dbPromise = null
+        void promise.then(
+            db => {
+                db.close()
+            },
+            () => {
+                // upup-catch: the open already failed; nothing to close.
+            },
+        )
     }
 
     async get(key: string): Promise<unknown> {
@@ -66,12 +119,6 @@ export class IndexedDBStorage implements PersistentStorage {
                 }
                 request.onerror = () => {
                     reject(request.error ?? new Error('IndexedDB get failed'))
-                }
-                tx.oncomplete = () => {
-                    db.close()
-                }
-                tx.onerror = () => {
-                    db.close()
                 }
             })
         } catch {
@@ -95,12 +142,6 @@ export class IndexedDBStorage implements PersistentStorage {
                 request.onerror = () => {
                     reject(request.error ?? new Error('IndexedDB put failed'))
                 }
-                tx.oncomplete = () => {
-                    db.close()
-                }
-                tx.onerror = () => {
-                    db.close()
-                }
             })
         } catch {
             // upup-catch: crash recovery is best-effort — persistence failures
@@ -123,12 +164,6 @@ export class IndexedDBStorage implements PersistentStorage {
                     reject(
                         request.error ?? new Error('IndexedDB delete failed'),
                     )
-                }
-                tx.oncomplete = () => {
-                    db.close()
-                }
-                tx.onerror = () => {
-                    db.close()
                 }
             })
         } catch {

--- a/packages/core/src/strategies/multipart-upload.ts
+++ b/packages/core/src/strategies/multipart-upload.ts
@@ -58,12 +58,15 @@ export interface MultipartUploadOptions {
      */
     retryDelays?: number[] | undefined
     /**
-     * Watchdog for a single part attempt (the sign call + the part PUT). A
-     * request that neither succeeds nor fails within this window is aborted
-     * and counted as a transient failure, so a hung connection costs one
-     * `retryDelays` slot instead of hanging the whole upload forever. Size it
-     * for the slowest link a part must traverse: the default allows a 5 MiB
-     * part ~230 kbit/s.
+     * Watchdog budget applied to each PHASE of a part attempt separately: the
+     * sign call, the source read (parts small enough to be materialized —
+     * see MATERIALIZE_PART_MAX_BYTES), and the PUT, where it is an INACTIVITY
+     * window reset by upload progress. A phase that neither succeeds nor
+     * fails within its window is aborted and counted as a transient failure,
+     * so a hung connection or a hung blob read costs one `retryDelays` slot
+     * instead of hanging the whole upload forever (worst case per attempt is
+     * therefore up to 3 × this value, not 1 ×). A slow-but-progressing PUT is
+     * never aborted — only one with no forward motion at all.
      */
     partTimeoutMs?: number | undefined
 }
@@ -72,6 +75,11 @@ const DEFAULT_CHUNK_SIZE = 5 * 1024 * 1024 // 5 MiB
 const DEFAULT_MAX_CONCURRENT = 3
 const DEFAULT_RETRY_DELAYS = [0, 1000, 3000, 5000]
 const DEFAULT_PART_TIMEOUT_MS = 180_000
+/** Parts at or under this size are materialized to an ArrayBuffer before the
+ *  PUT (the Firefox revived-blob fix in putPart); larger parts keep streaming
+ *  as Blobs so huge files (partSize grows with file size past ~48 GiB via the
+ *  10,000-part cap) can't turn the fix into an unbounded-heap regression. */
+const MATERIALIZE_PART_MAX_BYTES = 16 * 1024 * 1024
 /** S3's hard cap on parts per upload. `@upupjs/server` already sizes parts to
  *  respect it (providers/aws.ts computePartSize); this client-side floor covers
  *  servers that return no partSize, where the 5 MiB default would otherwise
@@ -406,7 +414,9 @@ export class MultipartUpload implements UploadStrategy {
      * penalizing the slow one. Mirrors the XHR PUT in direct-upload.ts.
      *
      * Resolves with the part's ETag. Rejects with: the retryable stall on
-     * inactivity (`partStallError`); `UpupNetworkError('Upload aborted')` when
+     * inactivity (`partStallError`) — covering both the slice READ and the PUT;
+     * a retryable `UPLOAD_FAILED` when the slice read itself rejects;
+     * `UpupNetworkError('Upload aborted')` when
      * the caller's signal aborts; a retryable `TypeError` on a network-level
      * failure (the shape `fetch` produced, which `isRetryablePartFailure`
      * already classifies); or an `uploadErrorFromResponse` on a non-2xx — its
@@ -415,12 +425,80 @@ export class MultipartUpload implements UploadStrategy {
      * old `await response.text()` ran AFTER the watchdog was cleared and could
      * hang a half-dead connection forever on the body read).
      */
-    private putPart(
+    private async putPart(
         signed: MultipartSignPartResponse,
         chunk: Blob,
         partNumber: number,
         signal: AbortSignal,
     ): Promise<string> {
+        // Materialize the slice to an ArrayBuffer BEFORE handing it to XHR.
+        // Firefox streams a Blob body lazily during send(); when the Blob is a
+        // slice of a File revived from IndexedDB after a page reload, that lazy
+        // read can stall — the request headers go out but the body never does,
+        // so the store times out the part (observed as a 503 storm on both
+        // MinIO and Backblaze B2, Firefox-only, reload-resume-only; the same
+        // revived blob READS fine via arrayBuffer(), so only the lazy XHR
+        // streaming path is affected). Reading the bytes up front turns a
+        // broken source into a clean rejection instead of a hanging bodyless
+        // request: a read REJECTION (Firefox NotReadableError on an
+        // evicted/stale blob) is a retryable failure that costs one
+        // `retryDelays` slot — the retry re-slices the SAME File, so it
+        // recovers only if the backing store does — and a read that never
+        // settles falls under the same `partTimeoutMs` inactivity budget as
+        // the PUT. The caller's signal joins the race so pause/cancel/destroy
+        // interrupt a hung read immediately instead of waiting the budget out.
+        //
+        // Size-gated: partSize GROWS with file size (the 10,000-part cap
+        // raises it past 5 MiB above ~48 GiB), and per the XHR spec send()
+        // copies a BufferSource — so materializing an arbitrarily large part
+        // would trade this Firefox-only stall for an unbounded-heap
+        // regression in every browser. Oversized parts keep the streaming
+        // Blob path (the pre-fix behavior); at the ceiling the transient cost
+        // is bounded by maxConcurrentParts × 2 × MATERIALIZE_PART_MAX_BYTES.
+        if (isAborted(signal)) {
+            throw new UpupNetworkError('Upload aborted')
+        }
+        let body: ArrayBuffer | Blob = chunk
+        if (chunk.size <= MATERIALIZE_PART_MAX_BYTES) {
+            let readTimer: ReturnType<typeof setTimeout> | undefined
+            let onReadAbort: (() => void) | undefined
+            body = await Promise.race([
+                chunk.arrayBuffer().catch((cause: unknown) => {
+                    const readErr = new UpupError(
+                        `Part ${partNumber} source read failed: ${
+                            cause instanceof Error
+                                ? cause.message
+                                : String(cause)
+                        }`,
+                        UpupErrorCode.UPLOAD_FAILED,
+                        true,
+                    )
+                    throw readErr
+                }),
+                new Promise<never>((_, reject) => {
+                    readTimer = setTimeout(() => {
+                        reject(partStallError(partNumber, this.partTimeoutMs))
+                    }, this.partTimeoutMs)
+                }),
+                new Promise<never>((_, reject) => {
+                    onReadAbort = () => {
+                        const abortErr = new UpupNetworkError('Upload aborted')
+                        reject(abortErr)
+                    }
+                    signal.addEventListener('abort', onReadAbort, {
+                        once: true,
+                    })
+                }),
+            ]).finally(() => {
+                clearTimeout(readTimer)
+                if (onReadAbort) {
+                    signal.removeEventListener('abort', onReadAbort)
+                }
+            })
+        }
+        if (isAborted(signal)) {
+            throw new UpupNetworkError('Upload aborted')
+        }
         return new Promise<string>((resolve, reject) => {
             const xhr = new XMLHttpRequest()
             let stalled = false
@@ -502,7 +580,7 @@ export class MultipartUpload implements UploadStrategy {
             // Arm before send so a connection that stalls before its first
             // progress event still trips the watchdog.
             armWatchdog()
-            xhr.send(chunk)
+            xhr.send(body)
         })
     }
 

--- a/packages/core/tests/crash-recovery-indexeddb-connection.test.ts
+++ b/packages/core/tests/crash-recovery-indexeddb-connection.test.ts
@@ -1,0 +1,218 @@
+// Contract: IndexedDBStorage holds ONE cached connection for its lifetime —
+// it must never close the database after an operation.
+//
+// Firefox ties Blob/File handles read from IndexedDB to the connection they
+// were read over. The crash-recovery restore hands the strategy a File revived
+// from the snapshot; with the old open-per-operation/close-on-complete
+// lifecycle, Firefox invalidated that File's backing store shortly after the
+// restore's transaction closed, and mid-resume slice reads started rejecting
+// with AbortError ("The operation was aborted") — reproduced live as a
+// Firefox-only reload-resume stall against both MinIO and Backblaze B2, while
+// Chromium (which materializes IndexedDB blobs independently of the
+// connection) never failed. Keeping the connection open keeps the revived
+// File readable for the whole resume.
+//
+// The cache must still yield: a `versionchange` (someone calling
+// deleteDatabase / upgrading in another tab) closes and drops it so the other
+// context is never blocked forever, and a browser-initiated `close` drops it
+// so the next operation reopens instead of erroring on a dead handle.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { IndexedDBStorage } from '../src/crash-recovery'
+
+type Listener = (() => void) | null
+
+class FakeRequest<T = unknown> {
+    onsuccess: Listener = null
+    onerror: Listener = null
+    result: T | undefined
+    error: Error | null = null
+
+    succeed(result: T | undefined): void {
+        this.result = result
+        queueMicrotask(() => this.onsuccess?.())
+    }
+}
+
+interface FakeTx {
+    objectStore: (name: string) => FakeObjectStore
+    oncomplete: Listener
+    onerror: Listener
+}
+
+class FakeObjectStore {
+    constructor(
+        private data: Map<string, unknown>,
+        private tx: FakeTx,
+    ) {}
+
+    /** Fires the request's success, then the transaction's completion — the
+     *  real IDB ordering, and the moment the old lifecycle closed the db. */
+    private finish<T>(req: FakeRequest<T>, result: T | undefined): void {
+        req.succeed(result)
+        queueMicrotask(() => queueMicrotask(() => this.tx.oncomplete?.()))
+    }
+
+    get(key: string): FakeRequest {
+        const req = new FakeRequest()
+        this.finish(req, this.data.get(key))
+        return req
+    }
+
+    put(value: unknown, key: string): FakeRequest {
+        const req = new FakeRequest()
+        this.data.set(key, value)
+        this.finish(req, undefined)
+        return req
+    }
+
+    delete(key: string): FakeRequest {
+        const req = new FakeRequest()
+        this.data.delete(key)
+        this.finish(req, undefined)
+        return req
+    }
+}
+
+class FakeDB {
+    onversionchange: Listener = null
+    onclose: Listener = null
+    readonly close = vi.fn()
+
+    constructor(private data: Map<string, unknown>) {}
+
+    createObjectStore(_name: string): void {}
+
+    transaction(_store: string, _mode: string): FakeTx {
+        const tx: FakeTx = {
+            objectStore: () => new FakeObjectStore(this.data, tx),
+            oncomplete: null,
+            onerror: null,
+        }
+        return tx
+    }
+}
+
+function installFakeIndexedDB(): {
+    openCalls: () => number
+    lastDB: () => FakeDB
+} {
+    const data = new Map<string, unknown>()
+    const dbs: FakeDB[] = []
+    const open = vi.fn((_name: string, _version: number) => {
+        const req = new FakeRequest<FakeDB>() as FakeRequest<FakeDB> & {
+            onupgradeneeded: Listener
+        }
+        req.onupgradeneeded = null
+        const db = new FakeDB(data)
+        dbs.push(db)
+        req.succeed(db)
+        return req
+    })
+    vi.stubGlobal('indexedDB', { open })
+    return {
+        openCalls: () => open.mock.calls.length,
+        lastDB: () => {
+            const db = dbs[dbs.length - 1]
+            if (!db) throw new Error('no FakeDB opened yet')
+            return db
+        },
+    }
+}
+
+let fake: ReturnType<typeof installFakeIndexedDB>
+
+beforeEach(() => {
+    fake = installFakeIndexedDB()
+})
+
+afterEach(() => {
+    vi.unstubAllGlobals()
+})
+
+describe('IndexedDBStorage connection lifecycle (Firefox revived-Blob contract)', () => {
+    it('reuses one cached connection across operations instead of opening per call', async () => {
+        const storage = new IndexedDBStorage()
+        await storage.set('k', { a: 1 })
+        await storage.get('k')
+        await storage.delete('k')
+        expect(fake.openCalls()).toBe(1)
+    })
+
+    it('never closes the connection after an operation — a revived File must stay readable for the whole resume', async () => {
+        const storage = new IndexedDBStorage()
+        await storage.set('k', { a: 1 })
+        expect(await storage.get('k')).toEqual({ a: 1 })
+        // The old lifecycle closed in tx.oncomplete, which fires AFTER the
+        // request settles — flush a macrotask so that moment has passed.
+        await new Promise(resolve => setTimeout(resolve, 0))
+        expect(fake.lastDB().close).not.toHaveBeenCalled()
+    })
+
+    it('versionchange closes and drops the cache so a deleteDatabase elsewhere is never blocked, and the next op reopens', async () => {
+        const storage = new IndexedDBStorage()
+        await storage.set('k', { a: 1 })
+        const first = fake.lastDB()
+
+        // Pre-assertions pinning the NEW lifecycle: without them this test
+        // also passes on the old open-per-operation code (which would have
+        // already closed in tx.oncomplete and would reopen anyway).
+        await new Promise(resolve => setTimeout(resolve, 0))
+        expect(first.close).not.toHaveBeenCalled()
+        expect(fake.openCalls()).toBe(1)
+
+        first.onversionchange?.()
+        expect(first.close).toHaveBeenCalledTimes(1)
+
+        await storage.get('k')
+        expect(fake.openCalls()).toBe(2)
+    })
+
+    it('a browser-initiated close drops the cache and the next operation reopens instead of using a dead handle', async () => {
+        const storage = new IndexedDBStorage()
+        await storage.set('k', { a: 1 })
+        const first = fake.lastDB()
+
+        // Same pre-assertions as above: pin that the cache was still live
+        // (old code would have closed and reopened regardless).
+        await new Promise(resolve => setTimeout(resolve, 0))
+        expect(first.close).not.toHaveBeenCalled()
+        expect(fake.openCalls()).toBe(1)
+
+        first.onclose?.()
+
+        expect(await storage.get('k')).toEqual({ a: 1 })
+        expect(fake.openCalls()).toBe(2)
+    })
+
+    it('close() releases the cached connection and the next operation reopens cleanly', async () => {
+        const storage = new IndexedDBStorage()
+        await storage.set('k', { a: 1 })
+        const first = fake.lastDB()
+
+        storage.close()
+        // close() resolves the cached promise before closing — flush it.
+        await new Promise(resolve => setTimeout(resolve, 0))
+        expect(first.close).toHaveBeenCalledTimes(1)
+
+        expect(await storage.get('k')).toEqual({ a: 1 })
+        expect(fake.openCalls()).toBe(2)
+    })
+
+    it("a stale connection's late close event does not wipe a newer cached connection", async () => {
+        const storage = new IndexedDBStorage()
+        await storage.set('k', { a: 1 })
+        const first = fake.lastDB()
+
+        // Browser closes the first connection; next op opens a second one.
+        first.onclose?.()
+        await storage.get('k')
+        expect(fake.openCalls()).toBe(2)
+
+        // A duplicate/late close from the FIRST connection must be ignored:
+        // the second connection stays cached, so no third open happens.
+        first.onclose?.()
+        await storage.get('k')
+        expect(fake.openCalls()).toBe(2)
+    })
+})

--- a/packages/core/tests/strategies/multipart-part-body-materialization.test.ts
+++ b/packages/core/tests/strategies/multipart-part-body-materialization.test.ts
@@ -1,0 +1,276 @@
+// Contract: a part PUT sends BYTES, never a lazy Blob reference.
+//
+// Firefox streams a Blob body lazily during XMLHttpRequest.send(). When the
+// Blob is a slice of a File revived from IndexedDB after a page reload
+// (crash-recovery's resume path), that lazy read can stall: the request
+// headers go out but the body never follows, so the storage backend times the
+// part out — observed live as a 503 storm on both single-node MinIO and real
+// Backblaze B2, Firefox-only, reload-resume-only, while the very same revived
+// blob read fine via arrayBuffer(). Materializing the slice BEFORE send()
+// turns a broken source into a clean, retryable rejection instead of a
+// hanging bodyless request. Materialization is capped: parts above
+// MATERIALIZE_PART_MAX_BYTES (16 MiB — partSize scales with file size via the
+// 10,000-part clamp) keep the streaming Blob path so huge files can't blow the
+// heap. These tests pin the contract: the body shape on both sides of the
+// ceiling, the retryable read rejection, the read stall cut off by its own
+// partTimeoutMs deadline (a separate window from the PUT watchdog), and abort
+// reaching an in-flight read.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { MultipartUpload } from '../../src/strategies/multipart-upload'
+import type { CredentialStrategy } from '../../src/contracts-strategies'
+import type { PresignedUrlResponse } from '@upupjs/core'
+import { installXhrPartMock, type PartRequest } from './xhr-part-mock'
+
+const PART = 1024 // tiny parts keep fixtures cheap; sizing math is unchanged
+
+// MultipartUpload never reads its `credentials` param (see the `_credentials`
+// name in src/strategies/multipart-upload.ts) — a minimal, type-correct
+// stand-in satisfies the UploadStrategy#upload signature.
+const unusedCredentials: PresignedUrlResponse = {
+    key: '',
+    uploadUrl: '',
+    expiresIn: 0,
+}
+
+function makeCredentials(partSize = PART): CredentialStrategy {
+    return {
+        getPresignedUrl: vi.fn(),
+        initMultipartUpload: vi.fn().mockResolvedValue({
+            key: 'uploads/big.zip',
+            uploadId: 'upload-123',
+            partSize,
+            expiresIn: 3600,
+            token: 'tok-abc',
+        }),
+        signPart: vi.fn().mockImplementation(async ({ partNumber }) => ({
+            uploadUrl: `https://s3/part${partNumber}?signed`,
+            expiresIn: 3600,
+        })),
+        completeMultipartUpload: vi.fn().mockResolvedValue({
+            key: 'uploads/big.zip',
+            etag: '"final"',
+        }),
+        abortMultipartUpload: vi.fn().mockResolvedValue(undefined),
+    }
+}
+
+const { puts, respondOk } = installXhrPartMock()
+
+function makeStrategy(overrides?: {
+    retryDelays?: number[]
+    partTimeoutMs?: number
+}): MultipartUpload {
+    return new MultipartUpload({
+        credentials: makeCredentials(),
+        chunkSizeBytes: PART,
+        maxConcurrentParts: 1,
+        retryDelays: overrides?.retryDelays ?? [0, 0],
+        partTimeoutMs: overrides?.partTimeoutMs ?? 60_000,
+    })
+}
+
+/** A File whose FIRST slice call yields a blob with the given arrayBuffer
+ *  behavior; every later call delegates to the real slice. Models the
+ *  reload-revived File whose first read misbehaves but whose source is
+ *  still intact for the retry. */
+function fileWithFirstSliceBroken(
+    parts: number,
+    brokenArrayBuffer: () => Promise<ArrayBuffer>,
+): File {
+    const file = new File([new ArrayBuffer(parts * PART)], 'big.zip', {
+        type: 'application/zip',
+    })
+    const realSlice = file.slice.bind(file)
+    let firstCall = true
+    Object.defineProperty(file, 'slice', {
+        value: (start?: number, end?: number): Blob => {
+            const real = realSlice(start, end)
+            if (!firstCall) return real
+            firstCall = false
+            // Delegate everything except arrayBuffer to the real slice.
+            return new Proxy(real, {
+                get(target, prop, receiver) {
+                    if (prop === 'arrayBuffer') return brokenArrayBuffer
+                    const value = Reflect.get(target, prop, receiver)
+                    return typeof value === 'function'
+                        ? value.bind(target)
+                        : value
+                },
+            })
+        },
+    })
+    return file
+}
+
+beforeEach(() => {
+    puts.mockReset()
+})
+
+describe('part body materialization (Firefox revived-blob stall)', () => {
+    it('every part PUT carries a materialized ArrayBuffer of exactly the slice bytes, never a lazy Blob', async () => {
+        respondOk()
+        const strategy = makeStrategy()
+        const file = new File([new ArrayBuffer(2 * PART + 100)], 'big.zip')
+
+        await strategy.upload(file, unusedCredentials, {
+            onProgress: vi.fn(),
+            signal: new AbortController().signal,
+        })
+
+        expect(puts).toHaveBeenCalledTimes(3)
+        const bodies = puts.mock.calls.map(
+            ([req]: [PartRequest, () => void]) => req.body,
+        )
+        for (const body of bodies) {
+            expect(body).toBeInstanceOf(ArrayBuffer)
+        }
+        expect((bodies[0] as ArrayBuffer).byteLength).toBe(PART)
+        expect((bodies[1] as ArrayBuffer).byteLength).toBe(PART)
+        expect((bodies[2] as ArrayBuffer).byteLength).toBe(100)
+    })
+
+    it('a part larger than the materialization ceiling keeps the streaming Blob path (no huge-file heap blow-up)', async () => {
+        respondOk()
+        const BIG = 16 * 1024 * 1024 + 1 // one byte over MATERIALIZE_PART_MAX_BYTES
+        const strategy = new MultipartUpload({
+            credentials: makeCredentials(BIG),
+            chunkSizeBytes: BIG,
+            maxConcurrentParts: 1,
+            retryDelays: [0],
+            partTimeoutMs: 60_000,
+        })
+        const file = new File([new ArrayBuffer(BIG)], 'big.zip')
+
+        await strategy.upload(file, unusedCredentials, {
+            onProgress: vi.fn(),
+            signal: new AbortController().signal,
+        })
+
+        expect(puts).toHaveBeenCalledTimes(1)
+        const bodies = puts.mock.calls.map(
+            ([req]: [PartRequest, () => void]) => req.body,
+        )
+        expect(bodies[0]).toBeInstanceOf(Blob)
+        expect((bodies[0] as Blob).size).toBe(BIG)
+    })
+
+    it('a slice read that REJECTS (NotReadableError) burns one retry slot and the re-read completes the upload', async () => {
+        respondOk()
+        const strategy = makeStrategy({ retryDelays: [0] })
+        const file = fileWithFirstSliceBroken(2, () =>
+            Promise.reject(
+                new DOMException(
+                    'The file could not be read',
+                    'NotReadableError',
+                ),
+            ),
+        )
+
+        await strategy.upload(file, unusedCredentials, {
+            onProgress: vi.fn(),
+            signal: new AbortController().signal,
+        })
+
+        // Part 1's first attempt died at the read (no PUT hit the wire), the
+        // retry re-sliced and uploaded it, then part 2 followed: 2 PUTs total.
+        expect(puts).toHaveBeenCalledTimes(2)
+    })
+
+    it('a slice read that NEVER SETTLES trips the partTimeoutMs read deadline and the retry completes the upload', async () => {
+        respondOk()
+        const strategy = makeStrategy({
+            retryDelays: [0],
+            partTimeoutMs: 50,
+        })
+        const file = fileWithFirstSliceBroken(
+            2,
+            () => new Promise<ArrayBuffer>(() => {}),
+        )
+
+        await strategy.upload(file, unusedCredentials, {
+            onProgress: vi.fn(),
+            signal: new AbortController().signal,
+        })
+
+        expect(puts).toHaveBeenCalledTimes(2)
+    })
+
+    it('aborting mid-read cancels the hanging source read immediately instead of waiting out the read deadline', async () => {
+        respondOk()
+        const strategy = makeStrategy({
+            retryDelays: [],
+            partTimeoutMs: 60_000,
+        })
+        const controller = new AbortController()
+        const file = fileWithFirstSliceBroken(
+            1,
+            () => new Promise<ArrayBuffer>(() => {}),
+        )
+
+        const settled = strategy
+            .upload(file, unusedCredentials, {
+                onProgress: vi.fn(),
+                signal: controller.signal,
+            })
+            .then(
+                () => null,
+                (err: unknown) => err,
+            )
+        // Let the upload reach the hanging read, then abort. With a 60s read
+        // deadline, only the abort arm of the race can settle this before the
+        // suite's own timeout — a hang here means abort never reached the read.
+        await new Promise(resolve => setTimeout(resolve, 25))
+        controller.abort()
+
+        const err = await settled
+        expect(err).toBeInstanceOf(Error)
+        expect((err as Error).message).toMatch(/abort/i)
+        expect(puts).not.toHaveBeenCalled()
+    })
+
+    it('the read deadline and the PUT watchdog are separate windows — a slow read does not shrink the PUT budget', async () => {
+        // partTimeoutMs=100; the read takes ~70ms and the PUT takes ~70ms.
+        // Each phase is inside its own window but their sum exceeds one
+        // window — success with a single PUT pins the "up to 3 ×, not 1 ×"
+        // docstring claim (the read timer must not keep running into the PUT).
+        puts.mockImplementation(async (req: PartRequest) => {
+            await new Promise(resolve => setTimeout(resolve, 70))
+            const partNumber = Number(/part(\d+)/.exec(req.url)?.[1] ?? '0')
+            return { status: 200, headers: { ETag: `"etag-${partNumber}"` } }
+        })
+        const strategy = makeStrategy({ retryDelays: [], partTimeoutMs: 100 })
+        const file = fileWithFirstSliceBroken(1, async () => {
+            await new Promise(resolve => setTimeout(resolve, 70))
+            return new ArrayBuffer(PART)
+        })
+
+        await strategy.upload(file, unusedCredentials, {
+            onProgress: vi.fn(),
+            signal: new AbortController().signal,
+        })
+
+        expect(puts).toHaveBeenCalledTimes(1)
+    })
+
+    it('a slice read rejection with an empty retry budget propagates as a retryable-classified failure, not a hang', async () => {
+        respondOk()
+        const strategy = makeStrategy({ retryDelays: [] })
+        const file = fileWithFirstSliceBroken(1, () =>
+            Promise.reject(
+                new DOMException(
+                    'The file could not be read',
+                    'NotReadableError',
+                ),
+            ),
+        )
+
+        await expect(
+            strategy.upload(file, unusedCredentials, {
+                onProgress: vi.fn(),
+                signal: new AbortController().signal,
+            }),
+        ).rejects.toThrow(/source read failed/)
+        expect(puts).not.toHaveBeenCalled()
+    })
+})


### PR DESCRIPTION
## The bug

Firefox-only, cross-reload-resume-only: after a page reload, resuming a multipart upload stalled and never completed. Chromium never failed; Firefox plain upload / quit-relaunch / re-pick all passed byte-exact. Reproduced deterministically (0/3) against **real Backblaze B2 over HTTPS**, ruling out every environment theory (MinIO single-node locks, tailnet latency, keep-alive reuse, part concurrency, pause/abort re-entrancy — each disproven by a dedicated instrumented run).

## Two-layer root cause (both proven by instrumentation)

1. **Firefox streams XHR Blob bodies lazily.** For a slice of an IndexedDB-revived File, `xhr.send(blob)` sent the request headers but never the body — the backend saw rx≈161 bytes, hit its 30s body-read timeout, and 503-stormed every subsequent part (39×503/run on B2). The same blob read fine via `arrayBuffer()` (probe: 12/12 slices <42ms) — an XHR-lazy-streaming bug, not a blob-read bug.
2. **Firefox ties Blob/File handles read from IndexedDB to the connection they were read over.** `IndexedDBStorage` closed the db after every operation, so the revived File's backing store died mid-resume: later parts' `chunk.arrayBuffer()` rejected with `AbortError` ("The operation was aborted"), burning all 4 upload-manager attempts. Chromium materializes IDB blobs independently of the connection and is unaffected.

## The fix

- `putPart` materializes each slice to an `ArrayBuffer` before `xhr.send`, raced against the `partTimeoutMs` deadline **and** the abort signal. Capped at `MATERIALIZE_PART_MAX_BYTES` (16 MiB): larger parts (partSize scales with file size past ~48 GiB via the 10,000-part clamp) keep the streaming Blob path, so transient memory is bounded by `maxConcurrentParts × min(partSize, 16 MiB)`.
- `IndexedDBStorage` holds **one cached connection** for its lifetime (identity-guarded `onclose`/`onversionchange` so a stale connection's late event can't wipe a newer cache), with a `close()` method wired into `UpupCore.destroy()` — the handle is released on unmount, the snapshot is not cleared, and user-supplied storages keep their own lifecycle (`PersistentStorage` stays a 3-method interface).

## Evidence (live, hash-verified vs real B2, 60 MB)

| Scenario | Before | After |
|---|---|---|
| firefox reload | **0/3** (503 storm / AbortError loop) | **5/5 + 2/2 on final build**, sha256 MATCH |
| chromium reload / firefox quit / chromium quit / firefox repick | pass | pass, sha256 MATCH |

The e2e harness is Chromium-only, so CI can never see this bug by construction (headless Firefox is additionally unstable on Windows runners — SWGL framebuffer crashes). Instead: two new vitest suites pin the fix **mechanisms** red-on-master/green-on-fix (`multipart-part-body-materialization.test.ts` — body shape both sides of the ceiling, retryable read rejection, read deadline, abort-during-read, read-window ≠ PUT-window; `crash-recovery-indexeddb-connection.test.ts` — one cached connection, never closed per-op, versionchange/close yield, `close()`, stale-event identity guard), and CLAUDE.md's "What the harness cannot catch" ledger now carries the Firefox trap with the live-repro re-verification recipe.

Docs: `resumable-uploads.mdx` updated to the corrected `partTimeoutMs` semantics (three phase windows — sign, source read, PUT — worst case 3×, not 1×) and the new per-part memory bound. Two patch changesets for `@upupjs/core`.

Reviewed by two independent Opus agents (correctness + rules/docs alignment); all findings addressed. Full gate run green: core 1692/1692, workspace 28/28, typecheck, eslint, oxlint, prettier, knip, vocab, test:quality, docs ×3, size, audit:prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)